### PR TITLE
[UDAF]Add max/min UDAF

### DIFF
--- a/be/src/vec/CMakeLists.txt
+++ b/be/src/vec/CMakeLists.txt
@@ -23,6 +23,7 @@ set(VEC_FILES
   aggregate_functions/aggregate_function_count.cpp
   aggregate_functions/aggregate_function_null.cpp
   aggregate_functions/aggregate_function_sum.cpp
+  aggregate_functions/aggregate_function_min_max.cpp
   columns/collator.cpp
   columns/column.cpp
   columns/column_const.cpp

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max.cpp
@@ -46,7 +46,8 @@ static IAggregateFunction * createAggregateFunctionSingleValue(const String & na
     // if (which.idx == TypeIndex::String)
     //     return new AggregateFunctionTemplate<Data<SingleValueDataString>, true>(argument_type);
 
-    return new AggregateFunctionTemplate<Data<SingleValueDataGeneric>, false>(argument_type);
+    // return new AggregateFunctionTemplate<Data<SingleValueDataGeneric>, false>(argument_type);
+    return nullptr;
 }
 
 AggregateFunctionPtr createAggregateFunctionMax(const std::string & name, const DataTypes & argument_types, const Array & parameters)
@@ -54,11 +55,18 @@ AggregateFunctionPtr createAggregateFunctionMax(const std::string & name, const 
     return AggregateFunctionPtr(createAggregateFunctionSingleValue<AggregateFunctionsSingleValue, AggregateFunctionMaxData>(name, argument_types, parameters));
 }
 
+AggregateFunctionPtr createAggregateFunctionMin(const std::string & name, const DataTypes & argument_types, const Array & parameters)
+{
+    return AggregateFunctionPtr(createAggregateFunctionSingleValue<AggregateFunctionsSingleValue, AggregateFunctionMinData>(name, argument_types, parameters));
+}
+
 } // namespace
 
 void registerAggregateFunctionMinMax(AggregateFunctionSimpleFactory& factory) {
     factory.registerFunction("max", createAggregateFunctionMax);
     factory.registerFunction("max", createAggregateFunctionMax, true);
+    factory.registerFunction("min", createAggregateFunctionMin);
+    factory.registerFunction("min", createAggregateFunctionMin, true);
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max.cpp
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/aggregate_functions/aggregate_function_min_max.h"
+#include <vec/aggregate_functions/factory_helpers.h>
+#include "vec/aggregate_functions/aggregate_function_simple_factory.h"
+#include <vec/aggregate_functions/helpers.h>
+
+namespace doris::vectorized {
+
+namespace {
+
+/// min, max
+template <template <typename, bool> class AggregateFunctionTemplate, template <typename> class Data>
+static IAggregateFunction * createAggregateFunctionSingleValue(const String & name, const DataTypes & argument_types, const Array & parameters)
+{
+    assertNoParameters(name, parameters);
+    assertUnary(name, argument_types);
+
+    const DataTypePtr & argument_type = argument_types[0];
+
+    WhichDataType which(argument_type);
+    #define DISPATCH(TYPE) \
+        if (which.idx == TypeIndex::TYPE) return new AggregateFunctionTemplate<Data<SingleValueDataFixed<TYPE>>, false>(argument_type);
+        FOR_NUMERIC_TYPES(DISPATCH)
+    #undef DISPATCH
+
+    // if (which.idx == TypeIndex::Date)
+    //     return new AggregateFunctionTemplate<Data<SingleValueDataFixed<DataTypeDate::FieldType>>, false>(argument_type);
+    // if (which.idx == TypeIndex::DateTime)
+    //     return new AggregateFunctionTemplate<Data<SingleValueDataFixed<DataTypeDateTime::FieldType>>, false>(argument_type);
+    // if (which.idx == TypeIndex::String)
+    //     return new AggregateFunctionTemplate<Data<SingleValueDataString>, true>(argument_type);
+
+    return new AggregateFunctionTemplate<Data<SingleValueDataGeneric>, false>(argument_type);
+}
+
+AggregateFunctionPtr createAggregateFunctionMax(const std::string & name, const DataTypes & argument_types, const Array & parameters)
+{
+    return AggregateFunctionPtr(createAggregateFunctionSingleValue<AggregateFunctionsSingleValue, AggregateFunctionMaxData>(name, argument_types, parameters));
+}
+
+} // namespace
+
+void registerAggregateFunctionMinMax(AggregateFunctionSimpleFactory& factory) {
+    factory.registerFunction("max", createAggregateFunctionMax);
+    factory.registerFunction("max", createAggregateFunctionMax, true);
+}
+
+} // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max.h
@@ -1,0 +1,627 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "vec/aggregate_functions/aggregate_function.h"
+#include "vec/columns/column_vector.h"
+
+#include "vec/common/assert_cast.h"
+
+namespace doris::vectorized {
+
+/// For numeric values.
+template <typename T>
+struct SingleValueDataFixed
+{
+private:
+    using Self = SingleValueDataFixed;
+
+    bool has_value = false; /// We need to remember if at least one value has been passed. This is necessary for AggregateFunctionIf.
+    T value;
+
+public:
+    bool has() const
+    {
+        return has_value;
+    }
+
+    void insertResultInto(IColumn & to) const
+    {
+        if (has())
+            assert_cast<ColumnVector<T> &>(to).getData().push_back(value);
+        else
+            assert_cast<ColumnVector<T> &>(to).insertDefault();
+    }
+
+    // void write(WriteBuffer & buf, const IDataType & /*data_type*/) const
+    // {
+    //     writeBinary(has(), buf);
+    //     if (has())
+    //         writeBinary(value, buf);
+    // }
+
+    // void read(ReadBuffer & buf, const IDataType & /*data_type*/, Arena *)
+    // {
+    //     readBinary(has_value, buf);
+    //     if (has())
+    //         readBinary(value, buf);
+    // }
+
+
+    void change(const IColumn & column, size_t row_num, Arena *)
+    {
+        has_value = true;
+        value = assert_cast<const ColumnVector<T> &>(column).getData()[row_num];
+    }
+
+    /// Assuming to.has()
+    void change(const Self & to, Arena *)
+    {
+        has_value = true;
+        value = to.value;
+    }
+
+    bool changeFirstTime(const IColumn & column, size_t row_num, Arena * arena)
+    {
+        if (!has())
+        {
+            change(column, row_num, arena);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    bool changeFirstTime(const Self & to, Arena * arena)
+    {
+        if (!has() && to.has())
+        {
+            change(to, arena);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    bool changeEveryTime(const IColumn & column, size_t row_num, Arena * arena)
+    {
+        change(column, row_num, arena);
+        return true;
+    }
+
+    bool changeEveryTime(const Self & to, Arena * arena)
+    {
+        if (to.has())
+        {
+            change(to, arena);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    bool changeIfLess(const IColumn & column, size_t row_num, Arena * arena)
+    {
+        if (!has() || assert_cast<const ColumnVector<T> &>(column).getData()[row_num] < value)
+        {
+            change(column, row_num, arena);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    bool changeIfLess(const Self & to, Arena * arena)
+    {
+        if (to.has() && (!has() || to.value < value))
+        {
+            change(to, arena);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    bool changeIfGreater(const IColumn & column, size_t row_num, Arena * arena)
+    {
+        if (!has() || assert_cast<const ColumnVector<T> &>(column).getData()[row_num] > value)
+        {
+            change(column, row_num, arena);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    bool changeIfGreater(const Self & to, Arena * arena)
+    {
+        if (to.has() && (!has() || to.value > value))
+        {
+            change(to, arena);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    bool isEqualTo(const Self & to) const
+    {
+        return has() && to.value == value;
+    }
+
+    bool isEqualTo(const IColumn & column, size_t row_num) const
+    {
+        return has() && assert_cast<const ColumnVector<T> &>(column).getData()[row_num] == value;
+    }
+};
+
+/** For strings. Short strings are stored in the object itself, and long strings are allocated separately.
+  * NOTE It could also be suitable for arrays of numbers.
+  */
+struct SingleValueDataString
+{
+private:
+    using Self = SingleValueDataString;
+
+    Int32 size = -1;    /// -1 indicates that there is no value.
+    Int32 capacity = 0;    /// power of two or zero
+    char * large_data;
+
+public:
+    static constexpr Int32 AUTOMATIC_STORAGE_SIZE = 64;
+    static constexpr Int32 MAX_SMALL_STRING_SIZE = AUTOMATIC_STORAGE_SIZE - sizeof(size) - sizeof(capacity) - sizeof(large_data);
+
+private:
+    char small_data[MAX_SMALL_STRING_SIZE]; /// Including the terminating zero.
+
+public:
+    bool has() const
+    {
+        return size >= 0;
+    }
+
+    const char * getData() const
+    {
+        return size <= MAX_SMALL_STRING_SIZE ? small_data : large_data;
+    }
+
+    StringRef getStringRef() const
+    {
+        return StringRef(getData(), size);
+    }
+
+    // void insertResultInto(IColumn & to) const
+    // {
+    //     if (has())
+    //         assert_cast<ColumnString &>(to).insertDataWithTerminatingZero(getData(), size);
+    //     else
+    //         assert_cast<ColumnString &>(to).insertDefault();
+    // }
+
+    // void write(WriteBuffer & buf, const IDataType & /*data_type*/) const
+    // {
+    //     writeBinary(size, buf);
+    //     if (has())
+    //         buf.write(getData(), size);
+    // }
+
+    // void read(ReadBuffer & buf, const IDataType & /*data_type*/, Arena * arena)
+    // {
+    //     Int32 rhs_size;
+    //     readBinary(rhs_size, buf);
+
+    //     if (rhs_size >= 0)
+    //     {
+    //         if (rhs_size <= MAX_SMALL_STRING_SIZE)
+    //         {
+    //             /// Don't free large_data here.
+
+    //             size = rhs_size;
+
+    //             if (size > 0)
+    //                 buf.read(small_data, size);
+    //         }
+    //         else
+    //         {
+    //             if (capacity < rhs_size)
+    //             {
+    //                 capacity = static_cast<UInt32>(roundUpToPowerOfTwoOrZero(rhs_size));
+    //                 /// Don't free large_data here.
+    //                 large_data = arena->alloc(capacity);
+    //             }
+
+    //             size = rhs_size;
+    //             buf.read(large_data, size);
+    //         }
+    //     }
+    //     else
+    //     {
+    //         /// Don't free large_data here.
+    //         size = rhs_size;
+    //     }
+    // }
+
+    /// Assuming to.has()
+    void changeImpl(StringRef value, Arena * arena)
+    {
+        // Int32 value_size = value.size;
+
+        // if (value_size <= MAX_SMALL_STRING_SIZE)
+        // {
+        //     /// Don't free large_data here.
+        //     size = value_size;
+
+        //     if (size > 0)
+        //         memcpy(small_data, value.data, size);
+        // }
+        // else
+        // {
+        //     if (capacity < value_size)
+        //     {
+        //         /// Don't free large_data here.
+        //         capacity = roundUpToPowerOfTwoOrZero(value_size);
+        //         large_data = arena->alloc(capacity);
+        //     }
+
+        //     size = value_size;
+        //     memcpy(large_data, value.data, size);
+        // }
+    }
+
+    void change(const IColumn & column, size_t row_num, Arena * arena)
+    {
+        // changeImpl(assert_cast<const ColumnString &>(column).getDataAtWithTerminatingZero(row_num), arena);
+    }
+
+    void change(const Self & to, Arena * arena)
+    {
+        changeImpl(to.getStringRef(), arena);
+    }
+
+    bool changeFirstTime(const IColumn & column, size_t row_num, Arena * arena)
+    {
+        if (!has())
+        {
+            change(column, row_num, arena);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    bool changeFirstTime(const Self & to, Arena * arena)
+    {
+        if (!has() && to.has())
+        {
+            change(to, arena);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    bool changeEveryTime(const IColumn & column, size_t row_num, Arena * arena)
+    {
+        change(column, row_num, arena);
+        return true;
+    }
+
+    bool changeEveryTime(const Self & to, Arena * arena)
+    {
+        if (to.has())
+        {
+            change(to, arena);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    // bool changeIfLess(const IColumn & column, size_t row_num, Arena * arena)
+    // {
+    //     if (!has() || assert_cast<const ColumnString &>(column).getDataAtWithTerminatingZero(row_num) < getStringRef())
+    //     {
+    //         change(column, row_num, arena);
+    //         return true;
+    //     }
+    //     else
+    //         return false;
+    // }
+
+    bool changeIfLess(const Self & to, Arena * arena)
+    {
+        if (to.has() && (!has() || to.getStringRef() < getStringRef()))
+        {
+            change(to, arena);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    // bool changeIfGreater(const IColumn & column, size_t row_num, Arena * arena)
+    // {
+    //     if (!has() || assert_cast<const ColumnString &>(column).getDataAtWithTerminatingZero(row_num) > getStringRef())
+    //     {
+    //         change(column, row_num, arena);
+    //         return true;
+    //     }
+    //     else
+    //         return false;
+    // }
+
+    bool changeIfGreater(const Self & to, Arena * arena)
+    {
+        if (to.has() && (!has() || to.getStringRef() > getStringRef()))
+        {
+            change(to, arena);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    bool isEqualTo(const Self & to) const
+    {
+        return has() && to.getStringRef() == getStringRef();
+    }
+
+    bool isEqualTo(const IColumn & column, size_t row_num) const
+    {
+        // return has() && assert_cast<const ColumnString &>(column).getDataAtWithTerminatingZero(row_num) == getStringRef();
+    }
+};
+
+/// For any other value types.
+struct SingleValueDataGeneric
+{
+private:
+    using Self = SingleValueDataGeneric;
+
+    Field value;
+
+public:
+    bool has() const
+    {
+        return !value.isNull();
+    }
+
+    void insertResultInto(IColumn & to) const
+    {
+        if (has())
+            to.insert(value);
+        else
+            to.insertDefault();
+    }
+
+    // void write(WriteBuffer & buf, const IDataType & data_type) const
+    // {
+    //     if (!value.isNull())
+    //     {
+    //         writeBinary(true, buf);
+    //         data_type.serializeBinary(value, buf);
+    //     }
+    //     else
+    //         writeBinary(false, buf);
+    // }
+
+    // void read(ReadBuffer & buf, const IDataType & data_type, Arena *)
+    // {
+    //     bool is_not_null;
+    //     readBinary(is_not_null, buf);
+
+    //     if (is_not_null)
+    //         data_type.deserializeBinary(value, buf);
+    // }
+
+    void change(const IColumn & column, size_t row_num, Arena *)
+    {
+        column.get(row_num, value);
+    }
+
+    void change(const Self & to, Arena *)
+    {
+        value = to.value;
+    }
+
+    bool changeFirstTime(const IColumn & column, size_t row_num, Arena * arena)
+    {
+        if (!has())
+        {
+            change(column, row_num, arena);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    bool changeFirstTime(const Self & to, Arena * arena)
+    {
+        if (!has() && to.has())
+        {
+            change(to, arena);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    bool changeEveryTime(const IColumn & column, size_t row_num, Arena * arena)
+    {
+        change(column, row_num, arena);
+        return true;
+    }
+
+    bool changeEveryTime(const Self & to, Arena * arena)
+    {
+        if (to.has())
+        {
+            change(to, arena);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    bool changeIfLess(const IColumn & column, size_t row_num, Arena * arena)
+    {
+        if (!has())
+        {
+            change(column, row_num, arena);
+            return true;
+        }
+        else
+        {
+            Field new_value;
+            column.get(row_num, new_value);
+            if (new_value < value)
+            {
+                value = new_value;
+                return true;
+            }
+            else
+                return false;
+        }
+    }
+
+    bool changeIfLess(const Self & to, Arena * arena)
+    {
+        if (to.has() && (!has() || to.value < value))
+        {
+            change(to, arena);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    bool changeIfGreater(const IColumn & column, size_t row_num, Arena * arena)
+    {
+        if (!has())
+        {
+            change(column, row_num, arena);
+            return true;
+        }
+        else
+        {
+            Field new_value;
+            column.get(row_num, new_value);
+            if (new_value > value)
+            {
+                value = new_value;
+                return true;
+            }
+            else
+                return false;
+        }
+    }
+
+    bool changeIfGreater(const Self & to, Arena * arena)
+    {
+        if (to.has() && (!has() || to.value > value))
+        {
+            change(to, arena);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    bool isEqualTo(const IColumn & column, size_t row_num) const
+    {
+        return has() && value == column[row_num];
+    }
+
+    bool isEqualTo(const Self & to) const
+    {
+        return has() && to.value == value;
+    }
+};
+
+template <typename Data>
+struct AggregateFunctionMaxData : Data
+{
+    using Self = AggregateFunctionMaxData;
+
+    bool changeIfBetter(const IColumn & column, size_t row_num, Arena * arena) { return this->changeIfGreater(column, row_num, arena); }
+    bool changeIfBetter(const Self & to, Arena * arena)                        { return this->changeIfGreater(to, arena); }
+
+    static const char * name() { return "max"; }
+};
+
+template <typename Data, bool AllocatesMemoryInArena>
+class AggregateFunctionsSingleValue final : public IAggregateFunctionDataHelper<Data, AggregateFunctionsSingleValue<Data, AllocatesMemoryInArena>>
+{
+private:
+    DataTypePtr & type;
+
+public:
+    AggregateFunctionsSingleValue(const DataTypePtr & type_)
+        : IAggregateFunctionDataHelper<Data, AggregateFunctionsSingleValue<Data, AllocatesMemoryInArena>>({type_}, {})
+        , type(this->argument_types[0])
+    {
+        if (StringRef(Data::name()) == StringRef("min")
+            || StringRef(Data::name()) == StringRef("max"))
+        {
+            if (!type->isComparable())
+                throw Exception("Illegal type " + type->getName() + " of argument of aggregate function " + getName()
+                    + " because the values of that data type are not comparable", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+        }
+    }
+
+    String getName() const override { return Data::name(); }
+
+    DataTypePtr getReturnType() const override
+    {
+        return type;
+    }
+
+    void add(AggregateDataPtr place, const IColumn ** columns, size_t row_num, Arena * arena) const override
+    {
+        this->data(place).changeIfBetter(*columns[0], row_num, arena);
+    }
+
+    void merge(AggregateDataPtr place, ConstAggregateDataPtr rhs, Arena * arena) const override
+    {
+        this->data(place).changeIfBetter(this->data(rhs), arena);
+    }
+
+    // void serialize(ConstAggregateDataPtr place, WriteBuffer & buf) const override
+    // {
+    //     this->data(place).write(buf, *type.get());
+    // }
+
+    // void deserialize(AggregateDataPtr place, ReadBuffer & buf, Arena * arena) const override
+    // {
+    //     this->data(place).read(buf, *type.get(), arena);
+    // }
+
+    bool allocatesMemoryInArena() const override
+    {
+        return AllocatesMemoryInArena;
+    }
+
+    void insertResultInto(ConstAggregateDataPtr place, IColumn & to) const override
+    {
+        this->data(place).insertResultInto(to);
+    }
+
+    const char * getHeaderFilePath() const override { return __FILE__; }
+};
+
+} // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_simple_factory.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_simple_factory.h
@@ -32,6 +32,7 @@ namespace doris::vectorized {
 class AggregateFunctionSimpleFactory;
 void registerAggregateFunctionSum(AggregateFunctionSimpleFactory& factory);
 void registerAggregateFunctionCombinatorNull(AggregateFunctionSimpleFactory& factory);
+void registerAggregateFunctionMinMax(AggregateFunctionSimpleFactory& factory);
 
 using DataTypePtr = std::shared_ptr<const IDataType>;
 using DataTypes = std::vector<DataTypePtr>;
@@ -66,9 +67,11 @@ public:
             }
         }
         if (nullable) {
-            return nullable_aggregate_functions[name](name, argument_types, parameters);
+            return nullable_aggregate_functions[name] == nullptr ? nullptr :
+                nullable_aggregate_functions[name](name, argument_types, parameters);
         } else {
-            return aggregate_functions[name](name, argument_types, parameters);
+            return aggregate_functions[name] == nullptr ? nullptr : 
+            aggregate_functions[name](name, argument_types, parameters);
         }
     }
 
@@ -79,6 +82,7 @@ public:
         std::call_once(oc, [&]() {
             registerAggregateFunctionSum(instance);
             registerAggregateFunctionCombinatorNull(instance);
+            registerAggregateFunctionMinMax(instance);
         });
         return instance;
     }


### PR DESCRIPTION
## Proposed changes

1 Support max/min UDAF for Integer Type
2 Fix core dump when calls a not implemented UDAF

Todo:
Support more type: date/string

Test case:
select min(col),max(col) from table
Single bucket, no shuffle