### PR TITLE
fix stream load fail

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/VectorizedUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/VectorizedUtil.java
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import org.apache.doris.qe.ConnectContext;
+
+public class VectorizedUtil {
+    public static boolean isVectorized() {
+        if (ConnectContext.get() == null) {
+            return false;
+        }
+        return ConnectContext.get().getSessionVariable().enableVectorizedEngine();
+    }
+}
+

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -30,7 +30,7 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.TreeNode;
 import org.apache.doris.common.UserException;
-import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.common.util.VectorizedUtil;
 import org.apache.doris.thrift.TExplainLevel;
 import org.apache.doris.thrift.TFunctionBinaryType;
 import org.apache.doris.thrift.TPlan;
@@ -132,7 +132,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
         this.tupleIds = Lists.newArrayList(tupleIds);
         this.tblRefIds = Lists.newArrayList(tupleIds);
         this.cardinality = -1;
-        this.planNodeName = ConnectContext.get().getSessionVariable().enableVectorizedEngine() ?
+        this.planNodeName = VectorizedUtil.isVectorized() ?
                 "V" + planNodeName : planNodeName;
         this.numInstances = 1;
     }
@@ -143,7 +143,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
         this.tupleIds = Lists.newArrayList();
         this.tblRefIds = Lists.newArrayList();
         this.cardinality = -1;
-        this.planNodeName = ConnectContext.get().getSessionVariable().enableVectorizedEngine() ?
+        this.planNodeName = VectorizedUtil.isVectorized() ?
                 "V" + planNodeName : planNodeName;
         this.numInstances = 1;
     }
@@ -160,7 +160,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
         this.conjuncts = Expr.cloneList(node.conjuncts, null);
         this.cardinality = -1;
         this.compactData = node.compactData;
-        this.planNodeName = ConnectContext.get().getSessionVariable().enableVectorizedEngine() ?
+        this.planNodeName = VectorizedUtil.isVectorized() ?
                 "V" + planNodeName : planNodeName;
         this.numInstances = 1;
     }


### PR DESCRIPTION
```
java.lang.NullPointerException: null
        at org.apache.doris.planner.PlanNode.<init>(PlanNode.java:135) ~[palo-fe.jar:3.4.0]
        at org.apache.doris.planner.ScanNode.<init>(ScanNode.java:42) ~[palo-fe.jar:3.4.0]
        at org.apache.doris.planner.LoadScanNode.<init>(LoadScanNode.java:56) ~[palo-fe.jar:3.4.0]
        at org.apache.doris.planner.StreamLoadScanNode.<init>(StreamLoadScanNode.java:75) ~[palo-fe.jar:3.4.0]
        at org.apache.doris.planner.StreamLoadPlanner.plan(StreamLoadPlanner.java:138) ~[palo-fe.jar:3.4.0]
        at org.apache.doris.service.FrontendServiceImpl.streamLoadPutImpl(FrontendServiceImpl.java:931) ~[palo-fe.jar:3.4.0]
        at org.apache.doris.service.FrontendServiceImpl.streamLoadPut(FrontendServiceImpl.java:893) [palo-fe.jar:3.4.0]
        at org.apache.doris.thrift.FrontendService$Processor$streamLoadPut.getResult(FrontendService.java:2053) [spark-dpp-1.0.0.jar:1.0.0]
        at org.apache.doris.thrift.FrontendService$Processor$streamLoadPut.getResult(FrontendService.java:2038) [spark-dpp-1.0.0.jar:1.0.0]
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:39) [spark-dpp-1.0.0.jar:1.0.0]
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39) [spark-dpp-1.0.0.jar:1.0.0]
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:286) [spark-dpp-1.0.0.jar:1.0.0]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_231]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_231]
```