### PR TITLE
support str_to_date, lpad, rpad

### DIFF
--- a/be/src/vec/CMakeLists.txt
+++ b/be/src/vec/CMakeLists.txt
@@ -88,6 +88,7 @@ set(VEC_FILES
   functions/functions_logical.cpp
   functions/function_cast.cpp
   functions/function_string.cpp
+  functions/function_timestamp.cpp
   functions/hll_cardinality.cpp
   functions/hll_empty.cpp
   functions/hll_hash.cpp

--- a/be/src/vec/functions/function_string.cpp
+++ b/be/src/vec/functions/function_string.cpp
@@ -416,6 +416,16 @@ struct StringAppendTrailingCharIfAbsent {
     }
 };
 
+struct StringLPad {
+    static constexpr auto name = "lpad";
+    static constexpr auto is_lpad = true;
+};
+
+struct StringRPad {
+    static constexpr auto name = "rpad";
+    static constexpr auto is_lpad = false;
+};
+
 template <typename LeftDataType, typename RightDataType>
 using StringStartsWithImpl = StringFunctionImpl<LeftDataType, RightDataType, StartsWithOp>;
 
@@ -459,6 +469,9 @@ using FunctionTrim = FunctionStringToString<TrimImpl<true, true>, NameTrim>;
 using FunctionStringAppendTrailingCharIfAbsent =
         FunctionBinaryStringOperateToNullType<StringAppendTrailingCharIfAbsent>;
 
+using FunctionStringLPad = FunctionStringPad<StringLPad>;
+using FunctionStringRPad = FunctionStringPad<StringRPad>;
+
 void registerFunctionString(SimpleFunctionFactory& factory) {
     // factory.registerFunction<>();
     factory.registerFunction<FunctionStringASCII>();
@@ -484,6 +497,8 @@ void registerFunctionString(SimpleFunctionFactory& factory) {
     factory.registerFunction<FunctionStringConcatWs>();
     factory.registerFunction<FunctionStringAppendTrailingCharIfAbsent>();
     factory.registerFunction<FunctionStringRepeat>();
+    factory.registerFunction<FunctionStringLPad>();
+    factory.registerFunction<FunctionStringRPad>();
 
     factory.registerAlias(FunctionLeft::name, "strleft");
     factory.registerAlias(FunctionRight::name, "strright");

--- a/be/src/vec/functions/function_string.cpp
+++ b/be/src/vec/functions/function_string.cpp
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 #include "vec/functions/function_string.h"
 
 #include <re2/re2.h>
@@ -348,10 +365,10 @@ struct StringSpace {
         res_offsets.resize(data.size());
         size_t input_size = res_offsets.size();
         fmt::memory_buffer buffer;
-        for(size_t i = 0;i < input_size;++i) {
+        for (size_t i = 0; i < input_size; ++i) {
             buffer.clear();
             if (data[i] > 0) {
-                for(size_t j = 0;j < data[i]; ++j) {
+                for (size_t j = 0; j < data[i]; ++j) {
                     buffer.push_back(' ');
                 }
                 StringOP::push_value_string(std::string_view(buffer.data(), buffer.size()), i,
@@ -384,17 +401,15 @@ struct StringAppendTrailingCharIfAbsent {
             const auto r_raw = reinterpret_cast<const char*>(&rdata[loffsets[i - 1]]);
 
             if (r_size == 0) {
-                StringOP::push_null_string(i, res_data, res_offsets,
-                                           null_map_data);
+                StringOP::push_null_string(i, res_data, res_offsets, null_map_data);
                 continue;
             }
             if (l_raw[l_size - 1] == r_raw[0]) {
-                StringOP::push_value_string(std::string_view(l_raw, l_size), i,
-                                            res_data, res_offsets);
+                StringOP::push_value_string(std::string_view(l_raw, l_size), i, res_data,
+                                            res_offsets);
                 continue;
             }
-            StringOP::push_value_string(std::string_view(l_raw, l_size), i,
-                                        res_data, res_offsets);
+            StringOP::push_value_string(std::string_view(l_raw, l_size), i, res_data, res_offsets);
             res_data[res_data.size() - 1] = *r_raw;
             res_data.push_back('\0');
         }
@@ -417,7 +432,7 @@ using StringFindInSetImpl = StringFunctionImpl<LeftDataType, RightDataType, Find
 using FunctionStringASCII = FunctionUnaryToType<StringASCII, NameStringASCII>;
 using FunctionStringLength = FunctionUnaryToType<StringLengthImpl, NameStringLenght>;
 using FunctionStringUTF8Length = FunctionUnaryToType<StringUtf8LengthImpl, NameStringUtf8Length>;
-using FunctionStringSpace = FunctionUnaryToType<StringSpace,NameStringSpace>;
+using FunctionStringSpace = FunctionUnaryToType<StringSpace, NameStringSpace>;
 using FunctionStringStartsWith =
         FunctionBinaryToType<DataTypeString, DataTypeString, StringStartsWithImpl, NameStartsWith>;
 using FunctionStringEndsWith =

--- a/be/src/vec/functions/function_timestamp.cpp
+++ b/be/src/vec/functions/function_timestamp.cpp
@@ -1,0 +1,47 @@
+#include "runtime/datetime_value.h"
+#include "vec/columns/column_nullable.h"
+#include "vec/columns/column_string.h"
+#include "vec/columns/column_vector.h"
+#include "vec/data_types/data_type_date.h"
+#include "vec/data_types/data_type_date_time.h"
+#include "vec/data_types/data_type_number.h"
+#include "vec/functions/function_totype.h"
+#include "vec/functions/simple_function_factory.h"
+
+namespace doris::vectorized {
+
+struct StrToDate {
+    static constexpr auto name = "str_to_date";
+    using ReturnType = DataTypeDateTime;
+    using ColumnType = ColumnVector<Int128>;
+
+    static void vector_vector(const ColumnString::Chars& ldata,
+                              const ColumnString::Offsets& loffsets,
+                              const ColumnString::Chars& rdata,
+                              const ColumnString::Offsets& roffsets, ColumnType::Container& res,
+                              NullMap& null_map) {
+        size_t size = loffsets.size();
+        res.resize(size);
+        for (size_t i = 0; i < size; ++i) {
+            const char* l_raw_str = reinterpret_cast<const char*>(&ldata[loffsets[i - 1]]);
+            int l_str_size = loffsets[i] - loffsets[i - 1] - 1;
+
+            const char* r_raw_str = reinterpret_cast<const char*>(&rdata[roffsets[i - 1]]);
+            int r_str_size = roffsets[i] - roffsets[i - 1] - 1;
+
+            auto& ts_val = *reinterpret_cast<DateTimeValue*>(&res[i]);
+            if (!ts_val.from_date_format_str(r_raw_str, r_str_size, l_raw_str, l_str_size)) {
+                null_map[i] = 1;
+            }
+            ts_val.to_datetime();
+        }
+    }
+};
+
+using FunctionStrToDate = FunctionBinaryStringOperateToNullType<StrToDate>;
+
+void registerFunctionStrToDate(SimpleFunctionFactory& factory) {
+    factory.registerFunction<FunctionStrToDate>();
+}
+
+} // namespace doris::vectorized

--- a/be/src/vec/functions/function_totype.h
+++ b/be/src/vec/functions/function_totype.h
@@ -288,7 +288,8 @@ public:
             Impl::vector_vector(ldata, loffsets, rdata, roffsets, res_data, res_offsets,
                                 null_map->getData());
         } else {
-            Impl::vector_vector(ldata, loffsets, rdata, roffsets, res->getData());
+            Impl::vector_vector(ldata, loffsets, rdata, roffsets, res->getData(),
+                                null_map->getData());
         }
 
         block.getByPosition(result).column =

--- a/be/src/vec/functions/simple_function_factory.h
+++ b/be/src/vec/functions/simple_function_factory.h
@@ -41,12 +41,13 @@ void registerFunctionModulo(SimpleFunctionFactory& factory);
 void registerFunctionBitmap(SimpleFunctionFactory& factory);
 void registerFunctionIsNull(SimpleFunctionFactory& factory);
 void registerFunctionIsNotNull(SimpleFunctionFactory& factory);
-void registerFunctionToTimeFuction(SimpleFunctionFactory & factory);
-void registerFunctionTimeOfFuction(SimpleFunctionFactory & factory);
+void registerFunctionToTimeFuction(SimpleFunctionFactory& factory);
+void registerFunctionTimeOfFuction(SimpleFunctionFactory& factory);
 void registerFunctionString(SimpleFunctionFactory& factory);
 void registerFunctionIn(SimpleFunctionFactory& factory);
 void registerFunctionIf(SimpleFunctionFactory& factory);
 void registerFunctionDateTimeComputation(SimpleFunctionFactory& factory);
+void registerFunctionStrToDate(SimpleFunctionFactory& factory);
 
 class SimpleFunctionFactory {
     using Creator = std::function<FunctionBuilderPtr()>;
@@ -63,7 +64,7 @@ public:
             registerFunction(Function::name, &Function::create);
     }
 
-    void registerAlias(const std::string &name, const std::string &alias) {
+    void registerAlias(const std::string& name, const std::string& alias) {
         function_creators[alias] = function_creators[name];
     }
 
@@ -110,6 +111,7 @@ public:
             registerFunctionIn(instance);
             registerFunctionIf(instance);
             registerFunctionDateTimeComputation(instance);
+            registerFunctionStrToDate(instance);
         });
         return instance;
     }

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -215,7 +215,7 @@ visible_functions = [
 
     [['str_to_date'], 'DATETIME', ['VARCHAR', 'VARCHAR'],
         '_ZN5doris18TimestampFunctions11str_to_dateEPN9doris_udf'
-        '15FunctionContextERKNS1_9StringValES6_'],
+        '15FunctionContextERKNS1_9StringValES6_', 'vec'],
     [['date_format'], 'VARCHAR', ['DATETIME', 'VARCHAR'],
         '_ZN5doris18TimestampFunctions11date_formatEPN9doris_udf'
         '15FunctionContextERKNS1_11DateTimeValERKNS1_9StringValE',

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -678,10 +678,10 @@ visible_functions = [
         '15FunctionContextERKNS1_9StringValERKNS1_6IntValE', 'vec'],
     [['lpad'], 'VARCHAR', ['VARCHAR', 'INT', 'VARCHAR'],
             '_ZN5doris15StringFunctions4lpadEPN9doris_udf'
-            '15FunctionContextERKNS1_9StringValERKNS1_6IntValES6_'],
+            '15FunctionContextERKNS1_9StringValERKNS1_6IntValES6_', 'vec'],
     [['rpad'], 'VARCHAR', ['VARCHAR', 'INT', 'VARCHAR'],
             '_ZN5doris15StringFunctions4rpadEPN9doris_udf'
-            '15FunctionContextERKNS1_9StringValERKNS1_6IntValES6_'],
+            '15FunctionContextERKNS1_9StringValERKNS1_6IntValES6_', 'vec'],
     [['append_trailing_char_if_absent'], 'VARCHAR', ['VARCHAR', 'VARCHAR'],
 	'_ZN5doris15StringFunctions30append_trailing_char_if_absentEPN9doris_udf15FunctionContextERKNS1_9StringValES6_', 'vec'],
     [['length'], 'INT', ['VARCHAR'],


### PR DESCRIPTION
```
select str_to_date(k5, '%Y-%m-%d %H:%i:%s') from baseall;
```

lpad/rpad