### PR TITLE
fix unmeaning materized in agg, reuse vector in vectorized agg calc

### DIFF
--- a/be/src/vec/core/materialize_block.h
+++ b/be/src/vec/core/materialize_block.h
@@ -26,4 +26,11 @@ namespace doris::vectorized {
 Block materialize_block(const Block& block);
 void materialize_block_inplace(Block& block);
 
+template <typename Iterator>
+void materialize_block_inplace(Block& block, Iterator start, Iterator end) {
+    for (; start < end;) {
+        block.replace_by_position_if_const(*start);
+        ++start;
+    }
+}
 } // namespace doris::vectorized

--- a/be/src/vec/exec/vintersect_node.cpp
+++ b/be/src/vec/exec/vintersect_node.cpp
@@ -44,7 +44,7 @@ Status VIntersectNode::open(RuntimeState* state) {
 }
 
 Status VIntersectNode::get_next(RuntimeState* state, Block* block, bool* eos) {
-    return Status::NotSupported("Not Implemented.");
+    return Status::NotSupported("Not Implemented VIntersectNode::get_next.");
 }
 
 Status VIntersectNode::close(RuntimeState* state) {

--- a/be/src/vec/exprs/vectorized_agg_fn.h
+++ b/be/src/vec/exprs/vectorized_agg_fn.h
@@ -73,7 +73,7 @@ private:
 
     AggFnEvaluator(const TExprNode& desc);
 
-    std::vector<const IColumn*> _get_argment_columns(Block* block) const;
+    void _calc_argment_columns(Block* block);
 
     const TypeDescriptor _return_type;
     const TypeDescriptor _intermediate_type;
@@ -93,6 +93,8 @@ private:
     AggregateFunctionPtr _function;
 
     std::string _expr_name;
+
+    std::vector<const IColumn*> _agg_columns;
 };
 } // namespace vectorized
 


### PR DESCRIPTION
before:
    VAGGREGATION_NODE (id=1):(Active: 15s151ms, % non-child: 60.62%)
        - BuildTime: 7s951ms
        - ExecTime: 607.570ms
        - ExprTime: 7s210ms
after:
    VAGGREGATION_NODE (id=1):(Active: 14s271ms, % non-child: 58.88%)
        - BuildTime: 6s319ms
        - ExecTime: 500.523ms
        - ExprTime: 5s708ms
