### PR TITLE
[BUG]fix expr's args type and return type check failed

### DIFF
--- a/be/src/vec/data_types/data_type.cpp
+++ b/be/src/vec/data_types/data_type.cpp
@@ -95,6 +95,8 @@ DataTypePtr IDataType::from_thrift(const doris::PrimitiveType& type, const bool 
     DataTypePtr result;
     switch (type) {
         case TYPE_BOOLEAN:
+            result = std::make_shared<DataTypeUInt8>();
+            break;
         case TYPE_TINYINT:
             result = std::make_shared<DataTypeInt8>();
             break;

--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -258,7 +258,7 @@ using FunctionBuilderPtr = std::shared_ptr<IFunctionBuilder>;
 class FunctionBuilderImpl : public IFunctionBuilder {
 public:
     FunctionBasePtr build(const ColumnsWithTypeAndName& arguments, const DataTypePtr& return_type) const final {
-        DCHECK_EQ(return_type, get_return_type(arguments));
+        DCHECK(return_type->equals(*get_return_type(arguments)));
         return build_impl(arguments, return_type);
     }
 

--- a/be/src/vec/sink/mysql_result_writer.cpp
+++ b/be/src/vec/sink/mysql_result_writer.cpp
@@ -87,6 +87,11 @@ Status MysqlResultWriter::_add_one_column(const ColumnPtr& column_ptr) {
             }
         }
 
+        if constexpr (type == TYPE_BOOLEAN) {
+            //todo here need to using uint after MysqlRowBuffer support it
+            buf_ret = _vec_buffers[i]->push_tinyint(static_cast<int8_t>(column->get_int(i)));
+        }
+
         if constexpr (type == TYPE_TINYINT) {
             buf_ret = _vec_buffers[i]->push_tinyint(static_cast<int8_t>(column->get_int(i)));
         }
@@ -205,6 +210,12 @@ Status MysqlResultWriter::append_block(Block& block) {
 
         switch (_output_vexpr_ctxs[i]->root()->result_type()) {
         case TYPE_BOOLEAN:
+            if (type_ptr->is_nullable()) {
+                status = _add_one_column<PrimitiveType::TYPE_BOOLEAN, true>(column_ptr);
+            } else {
+                status = _add_one_column<PrimitiveType::TYPE_BOOLEAN, false>(column_ptr);
+            }
+            break;
         case TYPE_TINYINT: {
             if (type_ptr->is_nullable()) {
                 status = _add_one_column<PrimitiveType::TYPE_TINYINT, true>(column_ptr);

--- a/be/src/vec/sink/mysql_result_writer.cpp
+++ b/be/src/vec/sink/mysql_result_writer.cpp
@@ -89,11 +89,12 @@ Status MysqlResultWriter::_add_one_column(const ColumnPtr& column_ptr) {
 
         if constexpr (type == TYPE_BOOLEAN) {
             //todo here need to using uint after MysqlRowBuffer support it
-            buf_ret = _vec_buffers[i]->push_tinyint(static_cast<int8_t>(column->get_int(i)));
+            buf_ret = _vec_buffers[i]->push_tinyint(
+                assert_cast<const ColumnVector<UInt8>&>(*column).get_data()[i]);
         }
-
         if constexpr (type == TYPE_TINYINT) {
-            buf_ret = _vec_buffers[i]->push_tinyint(static_cast<int8_t>(column->get_int(i)));
+            buf_ret = _vec_buffers[i]->push_tinyint(
+                assert_cast<const ColumnVector<Int8>&>(*column).get_data()[i]);
         }
         if constexpr (type == TYPE_SMALLINT) {
             buf_ret = _vec_buffers[i]->push_smallint(


### PR DESCRIPTION
compile be BUILD_TYPE=DEBUG，run sql as 'select a + 1 from table' will cause be failed.
be.INFO as below
```
function.h:263] Check failed: return_type == get_return_type(arguments) (0xa44f410 vs. 0xa44feb0)
```
