### PR TITLE
Fix the error result of const expr

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -1768,6 +1768,9 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
             }
             return true;
         }
+        if (fn.functionName().equalsIgnoreCase("concat_ws")) {
+            return children.get(0).isNullable();
+        }
         return true;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExpressionFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExpressionFunctions.java
@@ -73,7 +73,7 @@ public enum ExpressionFunctions {
             // 1. Not UDF
             // 2. Not in NonNullResultWithNullParamFunctions
             // 3. Has null parameter
-            if (fn.getNullableMode() != Function.NullableMode.ALWAYS_NOT_NULLABLE
+            if (fn.getNullableMode() == Function.NullableMode.DEPEND_ON_ARGUMENT
                     && !fn.isUdf()) {
                 for (Expr e : constExpr.getChildren()) {
                     if (e instanceof NullLiteral) {

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -883,7 +883,7 @@ visible_functions = [
             '', '', 'vec', ''],
     [['concat_ws'], 'VARCHAR', ['VARCHAR', 'VARCHAR', '...'],
             '_ZN5doris15StringFunctions9concat_wsEPN9doris_udf'
-            '15FunctionContextERKNS1_9StringValEiPS5_', '', '', 'vec', ''],
+            '15FunctionContextERKNS1_9StringValEiPS5_', '', '', 'vec', 'CUSTOM'],
     [['find_in_set'], 'INT', ['VARCHAR', 'VARCHAR'],
             '_ZN5doris15StringFunctions11find_in_setEPN9doris_udf'
             '15FunctionContextERKNS1_9StringValES6_', '', '', 'vec', ''],


### PR DESCRIPTION
If the nullable mode of function is DEPEND_ON_ARGUMENT, the result will be null
    when there is null literal in argument.