### PR TITLE
[Bug]fix time type to_string One more '\0'

### DIFF
--- a/be/src/runtime/datetime_value.cpp
+++ b/be/src/runtime/datetime_value.cpp
@@ -396,19 +396,16 @@ char* DateTimeValue::to_datetime_string(char* to) const {
     to = append_date_string(to);
     *to++ = ' ';
     to = append_time_string(to);
-    *to++ = '\0';
     return to;
 }
 
 char* DateTimeValue::to_date_string(char* to) const {
     to = append_date_string(to);
-    *to++ = '\0';
     return to;
 }
 
 char* DateTimeValue::to_time_string(char* to) const {
     to = append_time_string(to);
-    *to++ = '\0';
     return to;
 }
 
@@ -424,7 +421,6 @@ char* DateTimeValue::to_string(char* to) const {
         to = to_datetime_string(to);
         break;
     default:
-        *to++ = '\0';
         break;
     }
     return to;


### PR DESCRIPTION
sql case:
select upper(k10), k11 from test limit 1;

wrong result:
1965-03-28\0

expect result:
1965-03-28