### PR TITLE
[Feature] add logic for peel pushed predicate at conjunct tree

### DIFF
--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -1660,21 +1660,19 @@ Status OlapScanNode::add_one_batch(RowBatchInterface* row_batch) {
 void OlapScanNode::debug_string(int /* indentation_level */, std::stringstream* /* out */) const {}
 
 vectorized::VExpr* OlapScanNode::_dfs_peel_conjunct(vectorized::VExpr* expr) {
-    if (!expr->is_and_expr()) {
-        // leaf expr condition
+    static constexpr auto is_leaf = [](vectorized::VExpr* expr) { return !expr->is_and_expr(); };
+
+    if (is_leaf(expr)) {
         return _pushed_conjuncts_index.count(_leaf_index++) ? nullptr : expr;
     } else {
         vectorized::VExpr* left_child = _dfs_peel_conjunct(expr->children()[0]);
         vectorized::VExpr* right_child = _dfs_peel_conjunct(expr->children()[1]);
-        // here do not close Expr* now
-        expr->set_child(0, left_child);
-        expr->set_child(1, right_child);
 
         if (left_child != nullptr && right_child != nullptr) {
+            expr->set_children({left_child, right_child});
             return expr;
-        } else if (left_child == nullptr && right_child == nullptr) {
-            return nullptr;
         }
+        // here do not close Expr* now
         return left_child != nullptr ? left_child : right_child;
     }
 }
@@ -1685,24 +1683,19 @@ vectorized::VExpr* OlapScanNode::_dfs_peel_conjunct(vectorized::VExpr* expr) {
 // Expr tree specific forms do not require requirements.
 void OlapScanNode::peel_pushed_conjuncts() {
     if (_vconjunct_ctx_ptr.get() == nullptr) return;
-    LOG(INFO) << "_peel_conjunct():"
-              << "start peel";
 
     _leaf_index = 0;
-
     vectorized::VExpr* conjunct_expr_root = (*_vconjunct_ctx_ptr.get())->root();
 
     if (conjunct_expr_root != nullptr) {
         vectorized::VExpr* new_conjunct_expr_root = _dfs_peel_conjunct(conjunct_expr_root);
         if (new_conjunct_expr_root == nullptr) {
             _vconjunct_ctx_ptr = nullptr;
-            LOG(INFO) << "new_vconjunct_expr_root is null";
+            _scanner_profile->add_info_string("VconjunctExprTree", "null");
         } else {
             (*_vconjunct_ctx_ptr.get())->set_root(new_conjunct_expr_root);
-            LOG(INFO) << "new_vconjunct_expr_root " << new_conjunct_expr_root->debug_string();
+            _scanner_profile->add_info_string("VconjunctExprTree", new_conjunct_expr_root->debug_string());
         }
-    } else {
-        LOG(INFO) << "_vconjunct_ctx_ptr->root() is null";
     }
 }
 

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -454,7 +454,7 @@ Status OlapScanNode::start_scan(RuntimeState* state) {
     RETURN_IF_ERROR(build_olap_filters());
 
     VLOG_CRITICAL << "Filter idle conjuncts";
-    // 4 Filter idle conjunct which already trans to olap filters
+    // 4. Filter idle conjunct which already trans to olap filters
     remove_pushed_conjuncts(state);
 
     VLOG_CRITICAL << "BuildScanKey";

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -1659,14 +1659,14 @@ Status OlapScanNode::add_one_batch(RowBatchInterface* row_batch) {
 
 void OlapScanNode::debug_string(int /* indentation_level */, std::stringstream* /* out */) const {}
 
-vectorized::VExpr* OlapScanNode::_dfs_peel_conjunct(vectorized::VExpr* expr) {
+vectorized::VExpr* OlapScanNode::_dfs_peel_conjunct(vectorized::VExpr* expr, int& _leaf_index) {
     static constexpr auto is_leaf = [](vectorized::VExpr* expr) { return !expr->is_and_expr(); };
 
     if (is_leaf(expr)) {
         return _pushed_conjuncts_index.count(_leaf_index++) ? nullptr : expr;
     } else {
-        vectorized::VExpr* left_child = _dfs_peel_conjunct(expr->children()[0]);
-        vectorized::VExpr* right_child = _dfs_peel_conjunct(expr->children()[1]);
+        vectorized::VExpr* left_child = _dfs_peel_conjunct(expr->children()[0], _leaf_index);
+        vectorized::VExpr* right_child = _dfs_peel_conjunct(expr->children()[1], _leaf_index);
 
         if (left_child != nullptr && right_child != nullptr) {
             expr->set_children({left_child, right_child});
@@ -1684,17 +1684,19 @@ vectorized::VExpr* OlapScanNode::_dfs_peel_conjunct(vectorized::VExpr* expr) {
 void OlapScanNode::_peel_pushed_conjuncts() {
     if (_vconjunct_ctx_ptr.get() == nullptr) return;
 
-    _leaf_index = 0;
+    int _leaf_index = 0;
     vectorized::VExpr* conjunct_expr_root = (*_vconjunct_ctx_ptr.get())->root();
 
     if (conjunct_expr_root != nullptr) {
-        vectorized::VExpr* new_conjunct_expr_root = _dfs_peel_conjunct(conjunct_expr_root);
+        vectorized::VExpr* new_conjunct_expr_root =
+                _dfs_peel_conjunct(conjunct_expr_root, _leaf_index);
         if (new_conjunct_expr_root == nullptr) {
             _vconjunct_ctx_ptr = nullptr;
             _scanner_profile->add_info_string("VconjunctExprTree", "null");
         } else {
             (*_vconjunct_ctx_ptr.get())->set_root(new_conjunct_expr_root);
-            _scanner_profile->add_info_string("VconjunctExprTree", new_conjunct_expr_root->debug_string());
+            _scanner_profile->add_info_string("VconjunctExprTree",
+                                              new_conjunct_expr_root->debug_string());
         }
     }
 }

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -369,8 +369,8 @@ protected:
 
     bool _is_pushed_index(int index) { return _pushed_conjuncts_index.count(index); }
     bool _is_leaf_expr(vectorized::VExpr* expr);
-    vectorized::VExpr* _dfs_peel_conjuct(vectorized::VExpr* expr);
-    void _peel_conjuct(); //remove pushed expr from conjuct tree
+    vectorized::VExpr* _dfs_peel_conjunct(vectorized::VExpr* expr);
+    void _peel_conjunct(); //remove pushed expr from conjunct tree
     int _leaf_index;
 };
 

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -367,9 +367,8 @@ protected:
 
     RuntimeProfile::Counter* _olap_wait_batch_queue_timer = nullptr;
 
-    vectorized::VExpr* _dfs_peel_conjunct(vectorized::VExpr* expr);
+    vectorized::VExpr* _dfs_peel_conjunct(vectorized::VExpr* expr, int& _leaf_index);
     void _peel_pushed_conjuncts(); // remove pushed expr from conjunct tree
-    int _leaf_index;
 };
 
 } // namespace doris

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -367,10 +367,8 @@ protected:
 
     RuntimeProfile::Counter* _olap_wait_batch_queue_timer = nullptr;
 
-    bool _is_pushed_index(int index) { return _pushed_conjuncts_index.count(index); }
-    bool _is_leaf_expr(vectorized::VExpr* expr);
     vectorized::VExpr* _dfs_peel_conjunct(vectorized::VExpr* expr);
-    void _peel_conjunct(); //remove pushed expr from conjunct tree
+    void peel_pushed_conjuncts(); //remove pushed expr from conjunct tree
     int _leaf_index;
 };
 

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -368,7 +368,7 @@ protected:
     RuntimeProfile::Counter* _olap_wait_batch_queue_timer = nullptr;
 
     vectorized::VExpr* _dfs_peel_conjunct(vectorized::VExpr* expr);
-    void peel_pushed_conjuncts(); //remove pushed expr from conjunct tree
+    void _peel_pushed_conjuncts(); // remove pushed expr from conjunct tree
     int _leaf_index;
 };
 

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -35,6 +35,7 @@
 #include "util/progress_updater.h"
 #include "util/spinlock.h"
 #include "vec/exec/volap_scanner.h"
+#include "vec/exprs/vexpr.h"
 
 namespace doris {
 class IRuntimeFilter;
@@ -365,6 +366,12 @@ protected:
     RuntimeProfile::Counter* _scanner_wait_worker_timer = nullptr;
 
     RuntimeProfile::Counter* _olap_wait_batch_queue_timer = nullptr;
+
+    bool _is_pushed_index(int index) { return _pushed_conjuncts_index.count(index); }
+    bool _is_leaf_expr(vectorized::VExpr* expr);
+    vectorized::VExpr* _dfs_peel_conjuct(vectorized::VExpr* expr);
+    void _peel_conjuct(); //remove pushed expr from conjuct tree
+    int _leaf_index;
 };
 
 } // namespace doris

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -367,7 +367,7 @@ protected:
 
     RuntimeProfile::Counter* _olap_wait_batch_queue_timer = nullptr;
 
-    vectorized::VExpr* _dfs_peel_conjunct(vectorized::VExpr* expr, int& _leaf_index);
+    vectorized::VExpr* _dfs_peel_conjunct(vectorized::VExpr* expr, int& leaf_index);
     void _peel_pushed_conjuncts(); // remove pushed expr from conjunct tree
 };
 

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -92,7 +92,7 @@ public:
 
 protected:
     RuntimeProfile::Counter* _bytes_read_counter; // # bytes read from the scanner
-    // # rows/tuples read from the scanner (including those discarded by eval_conjucts())
+    // # rows/tuples read from the scanner (including those discarded by eval_conjuncts())
     RuntimeProfile::Counter* _rows_read_counter;
     // Wall based aggregate read throughput [bytes/sec]
     RuntimeProfile::Counter* _total_throughput_counter;

--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -82,11 +82,17 @@ std::string VectorizedFnCall::debug_string() const {
     std::stringstream out;
     out << "VectorizedFn[";
     out << _expr_name;
-    out << "](";
+    out << "]{";
+    bool first = true;
     for (VExpr* input_expr : children()) {
-        out << " " << input_expr->debug_string() << ")";
+        if (first) {
+            first = false;
+        } else {
+            out << ",";
+        }
+        out << input_expr->debug_string();
     }
-    out << ")";
+    out << "}";
     return out.str();
 }
 

--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -41,8 +41,7 @@ doris::Status VectorizedFnCall::prepare(doris::RuntimeState* state,
         child_expr_name.emplace_back(child->expr_name());
     }
     _function = SimpleFunctionFactory::instance().get_function(_fn.name.function_name,
-                                                               argument_template,
-                                                               _data_type);
+                                                               argument_template, _data_type);
     if (_function == nullptr) {
         return Status::InternalError(
                 fmt::format("Function {} is not implemented", _fn.name.function_name));
@@ -81,7 +80,9 @@ const std::string& VectorizedFnCall::expr_name() const {
 }
 std::string VectorizedFnCall::debug_string() const {
     std::stringstream out;
-    out << "VectorizedFn(";
+    out << "VectorizedFn[";
+    out << _expr_name;
+    out << "](";
     for (VExpr* input_expr : children()) {
         out << " " << input_expr->debug_string() << ")";
     }

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -33,8 +33,7 @@ using doris::RowDescriptor;
 using doris::TypeDescriptor;
 
 VExpr::VExpr(const doris::TExprNode& node)
-        : _node_type(node.node_type),
-          _type(TypeDescriptor::from_thrift(node.type)) {
+        : _node_type(node.node_type), _type(TypeDescriptor::from_thrift(node.type)) {
     if (node.__isset.fn) {
         _fn = node.fn;
     }
@@ -45,8 +44,7 @@ VExpr::VExpr(const doris::TExprNode& node)
     }
 }
 
-VExpr::VExpr(const TypeDescriptor& type, bool is_slotref, bool is_nullable)
-        : _type(type) {
+VExpr::VExpr(const TypeDescriptor& type, bool is_slotref, bool is_nullable) : _type(type) {
     if (is_slotref) {
         _node_type = TExprNodeType::SLOT_REF;
     }
@@ -94,6 +92,7 @@ Status VExpr::create_expr(doris::ObjectPool* pool, const doris::TExprNode& texpr
     case doris::TExprNodeType::ARITHMETIC_EXPR:
     case doris::TExprNodeType::COMPOUND_PRED:
     case doris::TExprNodeType::BINARY_PRED:
+    case doris::TExprNodeType::INFO_FUNC:
     case doris::TExprNodeType::FUNCTION_CALL:
     case doris::TExprNodeType::COMPUTE_FUNCTION_CALL: {
         *expr = pool->add(new VectorizedFnCall(texpr_node));

--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -78,12 +78,12 @@ public:
                                           VExpr* parent, int* node_idx, VExpr** root_expr,
                                           VExprContext** ctx);
     const std::vector<VExpr*>& children() const { return _children; }
-    void set_child(int index, VExpr* expr) { _children[index] = expr; }
+    void set_children(std::vector<VExpr*> children) { _children = children; }
     virtual std::string debug_string() const;
     static std::string debug_string(const std::vector<VExpr*>& exprs);
     static std::string debug_string(const std::vector<VExprContext*>& ctxs);
 
-    bool is_AND_expr() { return _fn.name.function_name == "and"; }
+    bool is_and_expr() { return _fn.name.function_name == "and"; }
 
 protected:
     /// Simple debug string that provides no expr subclass-specific information

--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -78,9 +78,12 @@ public:
                                           VExpr* parent, int* node_idx, VExpr** root_expr,
                                           VExprContext** ctx);
     const std::vector<VExpr*>& children() const { return _children; }
+    void set_child(int index, VExpr* expr) { _children[index] = expr; }
     virtual std::string debug_string() const;
     static std::string debug_string(const std::vector<VExpr*>& exprs);
     static std::string debug_string(const std::vector<VExprContext*>& ctxs);
+
+    bool is_AND_expr() { return _fn.name.function_name == "and"; }
 
 protected:
     /// Simple debug string that provides no expr subclass-specific information

--- a/be/src/vec/exprs/vexpr_context.h
+++ b/be/src/vec/exprs/vexpr_context.h
@@ -35,6 +35,7 @@ public:
     doris::Status execute(doris::vectorized::Block* block, int* result_column_id);
 
     VExpr* root() { return _root; }
+    void set_root(VExpr* expr) { _root = expr; }
 
 private:
     VExpr* _root;


### PR DESCRIPTION
We can use preorder traversal to find predicate expr witch pushed down to storage layer, then we can remove those node on conjunct tree.