### PR TITLE
[Bug] fix DateType int_divide

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
@@ -280,8 +280,16 @@ public class ArithmeticExpr extends Expr {
                 case ADD:
                 case SUBTRACT:
                 case MOD:
+                    if (t1.isDecimalV2() || t2.isDecimalV2()) {
+                        castBinaryOp(findCommonType(t1, t2));
+                    }
+                    fn = getBuiltinFunction(analyzer, op.name, collectChildReturnTypes(),
+                            Function.CompareMode.IS_IDENTICAL);
+                    break;
                 case INT_DIVIDE:
-                    if (t1.isDecimalV2() || t2.isDecimalV2()) castBinaryOp(findCommonType(t1, t2));
+                    if (t1.isDateType() || t2.isDateType()) {
+                        castBinaryOp(Type.BIGINT);
+                    }
                     fn = getBuiltinFunction(analyzer, op.name, collectChildReturnTypes(),
                             Function.CompareMode.IS_IDENTICAL);
                     break;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
@@ -287,7 +287,10 @@ public class ArithmeticExpr extends Expr {
                             Function.CompareMode.IS_IDENTICAL);
                     break;
                 case INT_DIVIDE:
-                    if (t1.isDateType() || t2.isDateType()) {
+                    if (t1.isDecimalV2() || t2.isDecimalV2()) {
+                        castBinaryOp(findCommonType(t1, t2));
+                    }
+                    else if (t1.isDateType() || t2.isDateType()) {
                         castBinaryOp(Type.BIGINT);
                     }
                     fn = getBuiltinFunction(analyzer, op.name, collectChildReturnTypes(),


### PR DESCRIPTION
Some query like `LO_ORDERDATE DIV 10000` should cast datetype to bigint
detailMessage = Unexpected exception: No match for vec function '(`LO_ORDERDATE` DIV 10000)' with operand types DATE and SMALLINT