### PR TITLE
Fix open/close in VExpr and VExprContext initialization issue.

### DIFF
--- a/be/src/vec/exprs/vcast_expr.cpp
+++ b/be/src/vec/exprs/vcast_expr.cpp
@@ -51,18 +51,22 @@ doris::Status VCastExpr::prepare(doris::RuntimeState* state, const doris::RowDes
         return Status::NotSupported(
                 fmt::format("Function {} is not implemented", _fn.name.function_name));
     }
-    VExpr::_register_function_context(state, context);
+    VExpr::register_function_context(state, context);
     _expr_name = fmt::format("(CAST {}, TO {})", child_name, _target_data_type_name);
     return Status::OK();
 }
 
-doris::Status VCastExpr::open(doris::RuntimeState* state, VExprContext* context) {
-    RETURN_IF_ERROR(VExpr::open(state, context));
+doris::Status VCastExpr::open(doris::RuntimeState* state, VExprContext* context,
+                              FunctionContext::FunctionStateScope scope) {
+    RETURN_IF_ERROR(VExpr::open(state, context, scope));
+    RETURN_IF_ERROR(VExpr::init_function_context(context, scope, _function));
     return Status::OK();
 }
 
-void VCastExpr::close(doris::RuntimeState* state, VExprContext* context) {
-    VExpr::close(state, context);
+void VCastExpr::close(doris::RuntimeState* state, VExprContext* context,
+                      FunctionContext::FunctionStateScope scope) {
+    VExpr::close_function_context(context, scope, _function);
+    VExpr::close(state, context, scope);
 }
 
 doris::Status VCastExpr::execute(VExprContext* context, doris::vectorized::Block* block,

--- a/be/src/vec/exprs/vcast_expr.h
+++ b/be/src/vec/exprs/vcast_expr.h
@@ -28,8 +28,10 @@ public:
                                   int* result_column_id);
     virtual doris::Status prepare(doris::RuntimeState* state, const doris::RowDescriptor& desc,
                                   VExprContext* context);
-    virtual doris::Status open(doris::RuntimeState* state, VExprContext* context);
-    virtual void close(doris::RuntimeState* state, VExprContext* context);
+    virtual doris::Status open(doris::RuntimeState* state, VExprContext* context,
+                               FunctionContext::FunctionStateScope scope);
+    virtual void close(doris::RuntimeState* state, VExprContext* context,
+                       FunctionContext::FunctionStateScope scope);
     virtual VExpr* clone(doris::ObjectPool* pool) const override {
         return pool->add(new VCastExpr(*this));
     }

--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -22,7 +22,7 @@
 
 namespace doris::vectorized {
 VExprContext::VExprContext(VExpr* expr)
-        : _root(expr), _prepared(false), _opened(false), _closed(false) {}
+        : _root(expr), _is_clone(false), _prepared(false), _opened(false), _closed(false) {}
 
 doris::Status VExprContext::execute(doris::vectorized::Block* block, int* result_column_id) {
     return _root->execute(this, block, result_column_id);

--- a/be/src/vec/exprs/vexpr_context.h
+++ b/be/src/vec/exprs/vexpr_context.h
@@ -58,6 +58,8 @@ public:
                                int column_to_keep);
 
 private:
+    friend class VExpr;
+
     /// The expr tree this context is for.
     VExpr* _root;
 

--- a/be/src/vec/exprs/vin_predicate.h
+++ b/be/src/vec/exprs/vin_predicate.h
@@ -31,8 +31,10 @@ public:
                                   int* result_column_id);
     virtual doris::Status prepare(doris::RuntimeState* state, const doris::RowDescriptor& desc,
                                   VExprContext* context);
-    virtual doris::Status open(doris::RuntimeState* state, VExprContext* context);
-    virtual void close(doris::RuntimeState* state, VExprContext* context);
+    virtual doris::Status open(doris::RuntimeState* state, VExprContext* context,
+                               FunctionContext::FunctionStateScope scope);
+    virtual void close(doris::RuntimeState* state, VExprContext* context,
+                       FunctionContext::FunctionStateScope scope);
     virtual VExpr* clone(doris::ObjectPool* pool) const override {
         return pool->add(new VInPredicate(*this));
     }


### PR DESCRIPTION
## Proposed changes

-  Add function context related logic in `open`/`close` for in and cast.
-  Fix `_is_clone` initialization issue in  `VExprContext`.
  
## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
