### PR TITLE
refactor: olap scan & volap scan

### DIFF
--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -47,7 +47,7 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
                                   const TPlanFragmentExecParams& params,
                                   const RowDescriptor& row_desc,
                                   bool is_vec,
-                                  boost::scoped_ptr<DataSink>* sink,
+                                  std::unique_ptr<DataSink>* sink,
                                   DescriptorTbl& desc_tbl) {
     DataSink* tmp_sink = NULL;
 

--- a/be/src/exec/data_sink.h
+++ b/be/src/exec/data_sink.h
@@ -18,7 +18,6 @@
 #ifndef DORIS_BE_SRC_QUERY_EXEC_DATA_SINK_H
 #define DORIS_BE_SRC_QUERY_EXEC_DATA_SINK_H
 
-#include <boost/scoped_ptr.hpp>
 #include <vector>
 
 #include "common/status.h"
@@ -81,7 +80,7 @@ public:
                                    const TPlanFragmentExecParams& params,
                                    const RowDescriptor& row_desc,
                                    bool is_vec,
-                                   boost::scoped_ptr<DataSink>* sink,
+                                   std::unique_ptr<DataSink>* sink,
                                    DescriptorTbl& desc_tbl);
 
     // Returns the runtime profile for the sink.

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -733,6 +733,10 @@ Status ExecNode::QueryMaintenance(RuntimeState* state, const std::string& msg) {
     return state->check_query_state(msg);
 }
 
+Status ExecNode::get_next(RuntimeState* state, RowBatch* row_batch, bool* eos) {
+    return Status::NotSupported("Not Implemented get batch");
+}
+
 Status ExecNode::get_next(RuntimeState* state, vectorized::Block* block, bool* eos) {
     return Status::NotSupported("Not Implemented get block");
 }

--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -102,7 +102,7 @@ public:
     // row_batch's tuple_data_pool.
     // Caller must not be holding any io buffers. This will cause deadlock.
     // TODO: AggregationNode and HashJoinNode cannot be "re-opened" yet.
-    virtual Status get_next(RuntimeState* state, RowBatch* row_batch, bool* eos) = 0;
+    virtual Status get_next(RuntimeState* state, RowBatch* row_batch, bool* eos);
     virtual Status get_next(RuntimeState* state, vectorized::Block* block, bool* eos);
 
     // Resets the stream of row batches to be retrieved by subsequent GetNext() calls.
@@ -186,7 +186,7 @@ public:
     const RowDescriptor& row_desc() const { return _row_descriptor; }
     int64_t rows_returned() const { return _num_rows_returned; }
     int64_t limit() const { return _limit; }
-    bool reached_limit() { return _limit != -1 && _num_rows_returned >= _limit; }
+    bool reached_limit() const { return _limit != -1 && _num_rows_returned >= _limit; }
     const std::vector<TupleId>& get_tuple_ids() const { return _tuple_ids; }
 
     RuntimeProfile* runtime_profile() { return _runtime_profile.get(); }
@@ -293,7 +293,7 @@ protected:
     int64_t _limit; // -1: no limit
     int64_t _num_rows_returned;
 
-    boost::scoped_ptr<RuntimeProfile> _runtime_profile;
+    std::unique_ptr<RuntimeProfile> _runtime_profile;
 
     /// Account for peak memory used by this node
     std::shared_ptr<MemTracker> _mem_tracker;
@@ -303,7 +303,7 @@ protected:
 
     /// MemPool for allocating data structures used by expression evaluators in this node.
     /// Created in Prepare().
-    boost::scoped_ptr<MemPool> _expr_mem_pool;
+    std::unique_ptr<MemPool> _expr_mem_pool;
 
     RuntimeProfile::Counter* _rows_returned_counter;
     RuntimeProfile::Counter* _rows_returned_rate;

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -59,8 +59,6 @@ OlapScanNode::OlapScanNode(ObjectPool* pool, const TPlanNode& tnode, const Descr
           _eval_conjuncts_fn(nullptr),
           _runtime_filter_descs(tnode.runtime_filters) {}
 
-OlapScanNode::~OlapScanNode() {}
-
 Status OlapScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::init(tnode, state));
     _direct_conjunct_size = _conjunct_ctxs.size();
@@ -1675,8 +1673,6 @@ Status OlapScanNode::add_one_batch(RowBatch* row_batch) {
     _row_batch_added_cv.notify_one();
     return Status::OK();
 }
-
-void OlapScanNode::debug_string(int /* indentation_level */, std::stringstream* /* out */) const {}
 
 vectorized::VExpr* OlapScanNode::_dfs_peel_conjunct(vectorized::VExpr* expr, int& leaf_index) {
     static constexpr auto is_leaf = [](vectorized::VExpr* expr) { return !expr->is_and_expr(); };

--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -61,8 +61,6 @@ OlapScanner::OlapScanner(RuntimeState* runtime_state, OlapScanNode* parent, bool
     _rows_pushed_cond_filtered_counter = parent->_rows_pushed_cond_filtered_counter;
 }
 
-OlapScanner::~OlapScanner() {}
-
 Status OlapScanner::prepare(
         const TPaloScanRange& scan_range, const std::vector<OlapScanRange*>& key_ranges,
         const std::vector<TCondition>& filters,

--- a/be/src/exec/olap_scanner.h
+++ b/be/src/exec/olap_scanner.h
@@ -51,8 +51,6 @@ public:
     OlapScanner(RuntimeState* runtime_state, OlapScanNode* parent, bool aggregation,
                 bool need_agg_finalize, const TPaloScanRange& scan_range);
 
-    ~OlapScanner();
-
     Status prepare(const TPaloScanRange& scan_range, const std::vector<OlapScanRange*>& key_ranges,
                    const std::vector<TCondition>& filters,
                    const std::vector<std::pair<std::string, std::shared_ptr<IBloomFilterFuncBase>>>&

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -69,16 +69,15 @@ class ScanNode : public ExecNode {
 public:
     ScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
             : ExecNode(pool, tnode, descs) {}
-    virtual ~ScanNode() {}
 
     // Set up counters
-    virtual Status prepare(RuntimeState* state);
+    Status prepare(RuntimeState* state) override;
 
     // Convert scan_ranges into node-specific scan restrictions.  This should be
     // called after prepare()
     virtual Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) = 0;
 
-    virtual bool is_scan_node() const { return true; }
+    bool is_scan_node() const override { return true; }
 
     RuntimeProfile::Counter* bytes_read_counter() const { return _bytes_read_counter; }
     RuntimeProfile::Counter* rows_read_counter() const { return _rows_read_counter; }

--- a/be/src/runtime/buffered_block_mgr2.cc
+++ b/be/src/runtime/buffered_block_mgr2.cc
@@ -44,7 +44,6 @@ using std::mem_fn;
 using std::lock_guard;
 using std::mutex;
 using boost::scoped_array;
-using boost::shared_ptr;
 using std::unique_lock;
 
 namespace doris {
@@ -225,7 +224,7 @@ BufferedBlockMgr2::BufferedBlockMgr2(RuntimeState* state, TmpFileMgr* tmp_file_m
 Status BufferedBlockMgr2::create(RuntimeState* state, const std::shared_ptr<MemTracker>& parent,
                                  RuntimeProfile* profile, TmpFileMgr* tmp_file_mgr,
                                  int64_t mem_limit, int64_t block_size,
-                                 boost::shared_ptr<BufferedBlockMgr2>* block_mgr) {
+                                 std::shared_ptr<BufferedBlockMgr2>* block_mgr) {
     DCHECK(parent != nullptr);
     block_mgr->reset();
     {
@@ -567,7 +566,7 @@ BufferedBlockMgr2::~BufferedBlockMgr2() {
         // distinguish between the two expired pointers), and when the other
         // ~BufferedBlockMgr2() call occurs, it won't find an entry for this _query_id.
         if (it != _s_query_to_block_mgrs.end()) {
-            shared_ptr<BufferedBlockMgr2> mgr = it->second.lock();
+            std::shared_ptr<BufferedBlockMgr2> mgr = it->second.lock();
             if (mgr.get() == NULL) {
                 // The BufferBlockMgr object referenced by this entry is being deconstructed.
                 _s_query_to_block_mgrs.erase(it);

--- a/be/src/runtime/buffered_block_mgr2.h
+++ b/be/src/runtime/buffered_block_mgr2.h
@@ -288,7 +288,7 @@ public:
     // - buffer_size: maximum size of each buffer.
     static Status create(RuntimeState* state, const std::shared_ptr<MemTracker>& parent,
                          RuntimeProfile* profile, TmpFileMgr* tmp_file_mgr, int64_t mem_limit,
-                         int64_t buffer_size, boost::shared_ptr<BufferedBlockMgr2>* block_mgr);
+                         int64_t buffer_size, std::shared_ptr<BufferedBlockMgr2>* block_mgr);
 
     ~BufferedBlockMgr2();
 
@@ -579,7 +579,7 @@ private:
     bool _is_cancelled;
 
     // Counters and timers to track behavior.
-    boost::scoped_ptr<RuntimeProfile> _profile;
+    std::unique_ptr<RuntimeProfile> _profile;
 
     // These have a fixed value for the lifetime of the manager and show memory usage.
     RuntimeProfile::Counter* _mem_tracker_counter;
@@ -622,7 +622,7 @@ private:
     // map contains only weak ptrs. BufferedBlockMgr2s that are handed out are shared ptrs.
     // When all the shared ptrs are no longer referenced, the BufferedBlockMgr2
     // d'tor will be called at which point the weak ptr will be removed from the map.
-    typedef std::unordered_map<TUniqueId, boost::weak_ptr<BufferedBlockMgr2>> BlockMgrsMap;
+    typedef std::unordered_map<TUniqueId, std::weak_ptr<BufferedBlockMgr2>> BlockMgrsMap;
     static BlockMgrsMap _s_query_to_block_mgrs;
 
     // Unowned.

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -82,8 +82,6 @@ public:
     FragmentExecState(const TUniqueId& query_id, const TUniqueId& instance_id, int backend_num,
                       ExecEnv* exec_env, const TNetworkAddress& coord_addr);
 
-    ~FragmentExecState();
-
     Status prepare(const TExecPlanFragmentParams& params);
 
     // just no use now
@@ -166,8 +164,6 @@ private:
 
     int _timeout_second;
 
-    std::unique_ptr<std::thread> _exec_thread;
-
     // This context is shared by all fragments of this host in a query
     std::shared_ptr<QueryFragmentsCtx> _fragments_ctx;
 
@@ -208,8 +204,6 @@ FragmentExecState::FragmentExecState(const TUniqueId& query_id,
           _timeout_second(-1) {
     _start_time = DateTimeValue::local_time();
 }
-
-FragmentExecState::~FragmentExecState() {}
 
 Status FragmentExecState::prepare(const TExecPlanFragmentParams& params) {
     if (params.__isset.query_options) {

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -58,7 +58,7 @@ public:
     using FinishCallback = std::function<void(PlanFragmentExecutor*)>;
 
     FragmentMgr(ExecEnv* exec_env);
-    virtual ~FragmentMgr();
+    virtual ~FragmentMgr(); //why virtual dtor?
 
     // execute one plan fragment
     Status exec_plan_fragment(const TExecPlanFragmentParams& params);

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -18,7 +18,6 @@
 #ifndef DORIS_BE_RUNTIME_PLAN_FRAGMENT_EXECUTOR_H
 #define DORIS_BE_RUNTIME_PLAN_FRAGMENT_EXECUTOR_H
 
-#include <boost/scoped_ptr.hpp>
 #include <condition_variable>
 #include <functional>
 #include <vector>
@@ -191,12 +190,12 @@ private:
 
     // note that RuntimeState should be constructed before and destructed after `_sink' and `_row_batch',
     // therefore we declare it before `_sink' and `_row_batch'
-    boost::scoped_ptr<RuntimeState> _runtime_state;
+    std::unique_ptr<RuntimeState> _runtime_state;
     // Output sink for rows sent to this fragment. May not be set, in which case rows are
     // returned via get_next's row batch
     // Created in prepare (if required), owned by this object.
-    boost::scoped_ptr<DataSink> _sink;
-    boost::scoped_ptr<RowBatch> _row_batch;
+    std::unique_ptr<DataSink> _sink;
+    std::unique_ptr<RowBatch> _row_batch;
     std::unique_ptr<doris::vectorized::Block> _block;
 
     // Number of rows returned by this fragment
@@ -209,8 +208,6 @@ private:
     // multithreaded access.
     std::shared_ptr<QueryStatistics> _query_statistics;
     bool _collect_query_statistics_with_every_batch;
-
-    bool _enable_vectorized_engine;
 
     ObjectPool* obj_pool() { return _runtime_state->obj_pool(); }
 

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -19,7 +19,6 @@
 #define DORIS_BE_SRC_QUERY_RUNTIME_RUNTIME_STATE_H
 
 #include <atomic>
-#include <boost/scoped_ptr.hpp>
 #include <fstream>
 #include <memory>
 #include <mutex>
@@ -383,7 +382,7 @@ public:
 
 private:
     // Use a custom block manager for the query for testing purposes.
-    void set_block_mgr2(const boost::shared_ptr<BufferedBlockMgr2>& block_mgr) {
+    void set_block_mgr2(const std::shared_ptr<BufferedBlockMgr2>& block_mgr) {
         _block_mgr2 = block_mgr;
     }
 
@@ -422,7 +421,7 @@ private:
     // Receivers depend on the descriptor table and we need to guarantee that their control
     // blocks are removed from the data stream manager before the objects in the
     // descriptor table are destroyed.
-    boost::scoped_ptr<ObjectPool> _data_stream_recvrs_pool;
+    std::unique_ptr<ObjectPool> _data_stream_recvrs_pool;
 
     // Lock protecting _error_log and _unreported_error_idx
     std::mutex _error_log_lock;
@@ -464,12 +463,11 @@ private:
     // will not necessarily be set in all error cases.
     std::mutex _process_status_lock;
     Status _process_status;
-    //boost::scoped_ptr<MemPool> _udf_pool;
 
     // BufferedBlockMgr object used to allocate and manage blocks of input data in memory
     // with a fixed memory budget.
     // The block mgr is shared by all fragments for this query.
-    boost::shared_ptr<BufferedBlockMgr2> _block_mgr2;
+    std::shared_ptr<BufferedBlockMgr2> _block_mgr2;
 
     // This is the node id of the root node for this plan fragment. This is used as the
     // hash seed and has two useful properties:
@@ -513,7 +511,7 @@ private:
 
     /// Buffer reservation for this fragment instance - a child of the query buffer
     /// reservation. Non-NULL if 'query_state_' is not NULL.
-    boost::scoped_ptr<ReservationTracker> _instance_buffer_reservation;
+    std::unique_ptr<ReservationTracker> _instance_buffer_reservation;
 
     /// Pool of buffer reservations used to distribute initial reservations to operators
     /// in the query. Contains a ReservationTracker that is a child of

--- a/be/src/vec/exec/volap_scan_node.cpp
+++ b/be/src/vec/exec/volap_scan_node.cpp
@@ -33,7 +33,105 @@ VOlapScanNode::VOlapScanNode(ObjectPool* pool, const TPlanNode& tnode, const Des
     _free_blocks.reserve(_max_materialized_blocks);
 }
 
-VOlapScanNode::~VOlapScanNode() {}
+bool VOlapScanNode::memory_consume_too_large(RuntimeState* state) {
+    int64_t mem_limit, mem_consume;
+    if (auto tracker = state->fragment_mem_tracker()) {
+        mem_limit = tracker->limit();
+        mem_consume = tracker->consumption();
+    } else {
+        mem_limit = 512 * 1024 * 1024;
+        mem_consume = __sync_fetch_and_add(&_buffered_bytes, 0);
+    }
+    return mem_consume >= (mem_limit * 6 / 10);
+}
+
+int VOlapScanNode::start_scanner_thread_task(RuntimeState* state) {
+    int assigned_thread_num = 0;
+    std::list<VOlapScanner*> olap_scanners;
+
+    // copy to local
+    {
+        std::unique_lock<std::mutex> l(_scan_blocks_lock);
+        assigned_thread_num = _running_thread;
+
+        size_t thread_slot_num = 0;
+        if (!memory_consume_too_large(state)) {
+            thread_slot_num = _max_thread - assigned_thread_num;
+        } else { // Memory already exceed
+            if (_scan_blocks.empty()) {
+                if (assigned_thread_num == 0) {
+                    thread_slot_num = 1;
+                }
+            }
+        }
+
+        {
+            std::unique_lock<std::mutex> l(_volap_scanners_lock);
+            thread_slot_num = std::min(thread_slot_num, _volap_scanners.size());
+            auto it = _volap_scanners.begin(), ite = it;
+            std::advance(ite, thread_slot_num);
+            olap_scanners.splice(olap_scanners.end(), _volap_scanners, it, ite);
+        }
+
+        _running_thread += thread_slot_num;
+        assigned_thread_num += thread_slot_num;
+    }
+
+    PriorityThreadPool* thread_pool = state->exec_env()->scan_thread_pool();
+    auto iter = olap_scanners.begin();
+    while (iter != olap_scanners.end()) {
+        PriorityThreadPool::Task task;
+        task.work_function = std::bind(&VOlapScanNode::scanner_thread, this, *iter);
+        task.priority = _nice;
+        (*iter)->start_wait_worker_timer();
+        if (thread_pool->offer(task)) {
+            olap_scanners.erase(iter++);
+        } else {
+            LOG(FATAL) << "Failed to assign scanner task to thread pool!";
+        }
+        ++_total_assign_num;
+    }
+
+    return assigned_thread_num;
+}
+
+Block* VOlapScanNode::get_scan_block(int assigned_thread_num) {
+    Block* scan_block = NULL;
+
+    // scanner_row_num = 16k
+    // 16k * 10 * 12 * 8 = 15M(>2s)  --> nice=10
+    // 16k * 20 * 22 * 8 = 55M(>6s)  --> nice=0
+    while (_nice > 0 && _total_assign_num > (22 - _nice) * (20 - _nice) * 6) {
+        --_nice;
+    }
+
+    {
+        // 1 scanner idle task not empty, assign new scanner task
+        std::unique_lock<std::mutex> l(_scan_blocks_lock);
+
+        // 2 wait when all scanner are running & no result in queue
+        while (UNLIKELY(_running_thread == assigned_thread_num && _scan_blocks.empty() &&
+                        !_scanner_done)) {
+            SCOPED_TIMER(_scanner_wait_batch_timer);
+            _scan_block_added_cv.wait(l);
+        }
+
+        // 3 transfer result block when queue is not empty
+        if (LIKELY(!_scan_blocks.empty())) {
+            scan_block = _scan_blocks.front();
+            _scan_blocks.pop_front();
+
+            // delete scan_block if transfer thread should be stopped
+            // because scan_block wouldn't be useful anymore
+            if (UNLIKELY(_transfer_done)) {
+                delete scan_block;
+                scan_block = NULL;
+            }
+        }
+    }
+
+    return scan_block;
+}
 
 void VOlapScanNode::transfer_thread(RuntimeState* state) {
     // scanner open pushdown to scanThread
@@ -60,108 +158,21 @@ void VOlapScanNode::transfer_thread(RuntimeState* state) {
      *    nice值越大的，越优先获得的查询资源
      * 4. 定期提高队列内残留任务的优先级，避免大查询完全饿死
      *********************************/
-    PriorityThreadPool* thread_pool = state->exec_env()->scan_thread_pool();
     _total_assign_num = 0;
     _nice = 18 + std::max(0, 2 - (int)_volap_scanners.size() / 5);
-    std::list<VOlapScanner*> olap_scanners;
 
-    int64_t mem_limit = 512 * 1024 * 1024;
-    // TODO(zc): use memory limit
-    int64_t mem_consume = __sync_fetch_and_add(&_buffered_bytes, 0);
-    if (state->fragment_mem_tracker() != nullptr) {
-        mem_limit = state->fragment_mem_tracker()->limit();
-        mem_consume = state->fragment_mem_tracker()->consumption();
-    }
-    int max_thread = _max_materialized_blocks;
+    _max_thread = _max_materialized_blocks;
     if (config::doris_scanner_row_num > state->batch_size()) {
-        max_thread /= config::doris_scanner_row_num / state->batch_size();
+        _max_thread /= config::doris_scanner_row_num / state->batch_size();
     }
+
     // read from scanner
     while (LIKELY(status.ok())) {
-        int assigned_thread_num = 0;
-        // copy to local
-        {
-            std::unique_lock<std::mutex> l(_scan_blocks_lock);
-            assigned_thread_num = _running_thread;
-            // int64_t buf_bytes = __sync_fetch_and_add(&_buffered_bytes, 0);
-            // How many thread can apply to this query
-            size_t thread_slot_num = 0;
-            mem_consume = __sync_fetch_and_add(&_buffered_bytes, 0);
-            if (state->fragment_mem_tracker() != nullptr) {
-                mem_consume = state->fragment_mem_tracker()->consumption();
-            }
-            if (mem_consume < (mem_limit * 6) / 10) {
-                thread_slot_num = max_thread - assigned_thread_num;
-            } else {
-                // Memory already exceed
-                if (_scan_blocks.empty()) {
-                    if (assigned_thread_num == 0) {
-                        thread_slot_num = 1;
-                    }
-                }
-            }
-            thread_slot_num = std::min(thread_slot_num, _volap_scanners.size());
-            for (int i = 0; i < thread_slot_num; ++i) {
-                olap_scanners.push_back(_volap_scanners.front());
-                _volap_scanners.pop_front();
-                _running_thread++;
-                assigned_thread_num++;
-            }
-        }
-
-        auto iter = olap_scanners.begin();
-        while (iter != olap_scanners.end()) {
-            PriorityThreadPool::Task task;
-            task.work_function = boost::bind(&VOlapScanNode::scanner_thread, this, *iter);
-            task.priority = _nice;
-            (*iter)->start_wait_worker_timer();
-            if (thread_pool->offer(task)) {
-                olap_scanners.erase(iter++);
-            } else {
-                LOG(FATAL) << "Failed to assign scanner task to thread pool!";
-            }
-            ++_total_assign_num;
-        }
-
-        Block* scan_block = NULL;
-        {
-            // 1 scanner idle task not empty, assign new scanner task
-            std::unique_lock<std::mutex> l(_scan_blocks_lock);
-
-            // scanner_row_num = 16k
-            // 16k * 10 * 12 * 8 = 15M(>2s)  --> nice=10
-            // 16k * 20 * 22 * 8 = 55M(>6s)  --> nice=0
-            while (_nice > 0 && _total_assign_num > (22 - _nice) * (20 - _nice) * 6) {
-                --_nice;
-            }
-
-            // 2 wait when all scanner are running & no result in queue
-            while (UNLIKELY(_running_thread == assigned_thread_num && _scan_blocks.empty() &&
-                            !_scanner_done)) {
-                SCOPED_TIMER(_scanner_wait_batch_timer);
-                _scan_block_added_cv.wait(l);
-            }
-
-            // 3 transfer result block when queue is not empty
-            if (LIKELY(!_scan_blocks.empty())) {
-                scan_block = _scan_blocks.front();
-                _scan_blocks.pop_front();
-
-                // delete scan_block if transfer thread should be stopped
-                // because scan_block wouldn't be useful anymore
-                if (UNLIKELY(_transfer_done)) {
-                    delete scan_block;
-                    scan_block = NULL;
-                }
-            } else {
-                if (_scanner_done) {
-                    break;
-                }
-            }
-        }
-
-        if (NULL != scan_block) {
+        int assigned_thread_num = start_scanner_thread_task(state);
+        if (Block* scan_block = get_scan_block(assigned_thread_num)) {
             add_one_block(scan_block);
+        } else if (_scanner_done) {
+            break;
         }
     }
 
@@ -175,6 +186,18 @@ void VOlapScanNode::transfer_thread(RuntimeState* state) {
     std::unique_lock<std::mutex> l(_scan_blocks_lock);
     _scan_thread_exit_cv.wait(l, [this] { return _running_thread == 0; });
     VLOG_CRITICAL << "Scanner threads have been exited. TransferThread exit.";
+}
+
+Block* VOlapScanNode::get_block() {
+    {
+        std::lock_guard<std::mutex> l(_free_blocks_lock);
+        if (!_free_blocks.empty()) {
+            auto block = _free_blocks.back();
+            _free_blocks.pop_back();
+            return block;
+        }
+    }
+    return new Block();
 }
 
 void VOlapScanNode::scanner_thread(VOlapScanner* scanner) {
@@ -197,14 +220,14 @@ void VOlapScanNode::scanner_thread(VOlapScanner* scanner) {
         scanner->set_opened();
     }
 
-    std::vector<Block*> blocks;
-
     // Because we use thread pool to scan data from storage. One scanner can't
     // use this thread too long, this can starve other query's scanner. So, we
     // need yield this thread when we do enough work. However, OlapStorage read
     // data in pre-aggregate mode, then we can't use storage returned data to
     // judge if we need to yield. So we record all raw data read in this round
     // scan, if this exceed threshold, we yield this thread.
+    std::list<Block*> blocks;
+
     int64_t raw_rows_read = scanner->raw_rows_read();
     int64_t raw_rows_threshold = raw_rows_read + config::doris_scanner_row_num;
     while (!eos && raw_rows_read < raw_rows_threshold) {
@@ -215,21 +238,13 @@ void VOlapScanNode::scanner_thread(VOlapScanner* scanner) {
             break;
         }
 
-        Block* block = nullptr;
-        {
-            std::lock_guard<std::mutex> l(_free_blocks_lock);
-            if (!_free_blocks.empty()) {
-                block = _free_blocks.back();
-                _free_blocks.pop_back();
-            }
-        }
-
-        block = block == nullptr ? new Block() : block;
+        Block* block = get_block();
         status = scanner->get_block(_runtime_state, block, &eos);
         VLOG_ROW << "VOlapScanNode input rows: " << block->rows();
         if (!status.ok()) {
             LOG(WARNING) << "Scan thread read OlapScanner failed: " << status.to_string();
             eos = true;
+            delete block;
             break;
         }
         // 4. if status not ok, change status_.
@@ -246,7 +261,6 @@ void VOlapScanNode::scanner_thread(VOlapScanner* scanner) {
     }
 
     {
-        std::unique_lock<std::mutex> l(_scan_blocks_lock);
         // if we failed, check status.
         if (UNLIKELY(!status.ok())) {
             _transfer_done = true;
@@ -254,28 +268,29 @@ void VOlapScanNode::scanner_thread(VOlapScanner* scanner) {
             if (LIKELY(_status.ok())) {
                 _status = status;
             }
-        }
-
+        }  
+        
         bool global_status_ok = false;
         {
             std::lock_guard<SpinLock> guard(_status_mutex);
             global_status_ok = _status.ok();
         }
+
         if (UNLIKELY(!global_status_ok)) {
             eos = true;
-            for (auto b : blocks) {
-                delete b;
-            }
+            std::for_each(blocks.begin(), blocks.end(), std::default_delete<Block>());
         } else {
-            for (auto b : blocks) {
-                _scan_blocks.push_back(b);
-            }
+            std::unique_lock<std::mutex> l(_scan_blocks_lock);
+            _scan_blocks.splice(_scan_blocks.end(), blocks);
         }
+
         // If eos is true, we will process out of this lock block.
         if (!eos) {
+            std::unique_lock<std::mutex> l(_volap_scanners_lock);
             _volap_scanners.push_front(scanner);
         }
     }
+
     if (eos) {
         // close out of blocks lock. we do this before _progress update
         // that can assure this object can keep live before we finish.
@@ -294,10 +309,12 @@ void VOlapScanNode::scanner_thread(VOlapScanner* scanner) {
 
     // The transfer thead will wait for `_running_thread==0`, to make sure all scanner threads won't access class members.
     // Do not access class members after this code.
-    std::unique_lock<std::mutex> l(_scan_blocks_lock);
-    _running_thread--;
-    _scan_block_added_cv.notify_one();
-    _scan_thread_exit_cv.notify_one();
+    {
+        std::unique_lock<std::mutex> l(_scan_blocks_lock);
+        _running_thread--;
+        _scan_block_added_cv.notify_one();
+        _scan_thread_exit_cv.notify_one();
+    }
 }
 
 Status VOlapScanNode::add_one_block(Block* block) {

--- a/be/src/vec/exec/volap_scan_node.h
+++ b/be/src/vec/exec/volap_scan_node.h
@@ -23,43 +23,45 @@ namespace doris {
 class ObjectPool;
 class TPlanNode;
 class DescriptorTbl;
-class RowBatch;
+
 namespace vectorized {
 
-class VOlapScanner;
-
 class VOlapScanNode : public OlapScanNode {
+    friend class VOlapScanner;
 public:
     VOlapScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs);
-    ~VOlapScanNode();
-    virtual void transfer_thread(RuntimeState* state);
-    virtual void scanner_thread(VOlapScanner* scanner);
-    virtual Status get_next(RuntimeState* state, RowBatch* row_batch, bool* eos) {
-        return Status::NotSupported("Not Implemented VOlapScanNode Node::get_next scalar");
-    }
-    virtual Status get_next(RuntimeState* state, Block* block, bool* eos);
-    virtual Status add_one_block(Block* block);
-    virtual Status start_scan_thread(RuntimeState* state);
-    virtual Status close(RuntimeState* state);
-
-    friend class VOlapScanner;
 
 private:
+    void scanner_thread(VOlapScanner* scanner);
+    void transfer_thread(RuntimeState* state) override;
+    Status start_scan_thread(RuntimeState* state) override;
+
+    Status get_next(RuntimeState* state, Block* block, bool* eos) override;
+    Status close(RuntimeState* state) override;
+
+    Status add_one_block(Block* block);
+    bool memory_consume_too_large(RuntimeState* state);
+    int start_scanner_thread_task(RuntimeState* state);
+    Block* get_scan_block(int assigned_thread_num);
+    Block* get_block();
+
     std::list<Block*> _scan_blocks;
+    std::mutex _scan_blocks_lock;
+    std::condition_variable _scan_block_added_cv;
+
     std::vector<Block*> _materialized_blocks;
     std::mutex _blocks_lock;
     std::condition_variable _block_added_cv;
     std::condition_variable _block_consumed_cv;
 
-    std::mutex _scan_blocks_lock;
-    std::condition_variable _scan_block_added_cv;
-
     std::vector<Block*> _free_blocks;
     std::mutex _free_blocks_lock;
 
     std::list<VOlapScanner*> _volap_scanners;
+    std::mutex _volap_scanners_lock;
 
     int _max_materialized_blocks;
+    int _max_thread = 0;
 };
 } // namespace vectorized
 } // namespace doris


### PR DESCRIPTION
refactor, change list:
1. we should use std prior to boost lib，so use std::unique_ptr replace boost::scoped_ptr, use std::shared_ptr replace boost::shared_ptr
2. make get_next take RowBatch param the same with get_next take Block param,  ExecNode define default implement, subclass override this interface when necessary
3. use override replace virtual keyword in subclass, because override keyword will tell compiler check param and report error when the function signature of subclass not match the version in the superclass, this is recommended and is why override import to C++11.
4. add keyword const to the read-only member functions
5. remove unnecessary empty dtor,  why? please reference to rules of 3/5/0
6. rewrite VOlapScanNode::transfer_thread, improving the code' readability
7. delete useless member datas, it's code garbage
8. resolved memleak risk，the block will leak when get_block return value is not ok
9. other small modifications, such as use better mutex lock