### PR TITLE
[Refactor]Add VecDateTimeValue to remove DateTimeValue in Vectorization mode

### DIFF
--- a/be/src/util/binary_cast.hpp
+++ b/be/src/util/binary_cast.hpp
@@ -23,7 +23,7 @@
 #include "runtime/datetime_value.h"
 #include "runtime/decimalv2_value.h"
 #include "util/types.h"
-
+#include "vec/runtime/vdatetime_value.h"
 namespace doris {
 union TypeConverter {
     uint64_t u64;
@@ -56,6 +56,12 @@ union DateTimeInt128Union {
     ~DateTimeInt128Union() {}
 };
 
+union VecDateTimeInt64Union {
+    doris::vectorized::VecDateTimeValue dt;
+    __int64_t i64;
+    ~VecDateTimeInt64Union() {}
+};
+
 // similar to reinterpret_cast but won't break strict-aliasing rules
 template <typename From, typename To>
 To binary_cast(From from) {
@@ -66,11 +72,13 @@ To binary_cast(From from) {
     constexpr bool from_decv2_to_packed128 = match_v<From, DecimalV2Value, To, PackedInt128>;
     constexpr bool from_i128_to_dt = match_v<From, __int128_t, To, DateTimeValue>;
     constexpr bool from_dt_to_i128 = match_v<From, DateTimeValue, To, __int128_t>;
+    constexpr bool from_i64_to_dt = match_v<From, __int64_t, To, doris::vectorized::VecDateTimeValue>;
+    constexpr bool from_dt_to_i64 = match_v<From, doris::vectorized::VecDateTimeValue, To, __int64_t>;
     constexpr bool from_i128_to_decv2 = match_v<From, __int128_t, To, DecimalV2Value>;
     constexpr bool from_decv2_to_i128 = match_v<From, DecimalV2Value, To, __int128_t>;
 
     static_assert(from_u64_to_db || from_i64_to_db || from_db_to_i64 || from_db_to_u64 ||
-                  from_decv2_to_packed128 || from_i128_to_dt || from_dt_to_i128 ||
+                  from_decv2_to_packed128 || from_i128_to_dt || from_dt_to_i128 || from_i64_to_dt || from_dt_to_i64 ||
                   from_i128_to_decv2 || from_decv2_to_i128);
 
     if constexpr (from_u64_to_db) {
@@ -99,6 +107,12 @@ To binary_cast(From from) {
     } else if constexpr (from_dt_to_i128) {
         DateTimeInt128Union conv = {.dt = from};
         return conv.i128;
+    } else if constexpr (from_i64_to_dt) {
+        VecDateTimeInt64Union conv = {.i64 = from};
+        return conv.dt;
+    } else if constexpr (from_dt_to_i64) {
+        VecDateTimeInt64Union conv = {.dt = from};
+        return conv.i64;
     } else if constexpr (from_i128_to_decv2) {
         DecimalInt128Union conv;
         conv.i128 = from;

--- a/be/src/util/static_asserts.cpp
+++ b/be/src/util/static_asserts.cpp
@@ -17,7 +17,7 @@
 
 #include "runtime/datetime_value.h"
 #include "runtime/string_value.h"
-
+#include "vec/runtime/vdatetime_value.h"
 namespace doris {
 // This class is unused.  It contains static (compile time) asserts.
 // This is useful to validate struct sizes and other similar things
@@ -28,6 +28,7 @@ private:
     static_assert(offsetof(StringValue, len) == 8);
     // Datetime value
     static_assert(sizeof(DateTimeValue) == 16);
+    static_assert(sizeof(doris::vectorized::VecDateTimeValue) == 8);
     // static_assert(offsetof(DateTimeValue, _year) == 8);
 };
 

--- a/be/src/vec/CMakeLists.txt
+++ b/be/src/vec/CMakeLists.txt
@@ -132,6 +132,7 @@ set(VEC_FILES
   sink/result_sink.cpp
   sink/vdata_stream_sender.cpp
   sink/vtabet_sink.cpp
+  runtime/vdatetime_value.cpp
   runtime/vdata_stream_recvr.cpp
   runtime/vdata_stream_mgr.cpp
   runtime/vpartition_info.cpp

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max.cpp
@@ -46,7 +46,7 @@ static IAggregateFunction* create_aggregate_function_single_value(const String& 
         return new AggregateFunctionTemplate<Data<SingleValueDataString>, false>(argument_type);
     }
     if (which.idx == TypeIndex::DateTime || which.idx == TypeIndex::Date) {
-        return new AggregateFunctionTemplate<Data<SingleValueDataFixed<Int128>>, false>(argument_type);
+        return new AggregateFunctionTemplate<Data<SingleValueDataFixed<Int64>>, false>(argument_type);
     }
     if (which.idx == TypeIndex::Decimal128) {
         return new AggregateFunctionTemplate<Data<SingleValueDataFixed<DecimalV2Value>>, false>(argument_type);

--- a/be/src/vec/core/accurate_comparison.h
+++ b/be/src/vec/core/accurate_comparison.h
@@ -26,7 +26,7 @@
 #include "vec/common/nan_utils.h"
 #include "vec/common/uint128.h"
 #include "vec/core/types.h"
-
+#include "vec/runtime/vdatetime_value.h"
 /** Preceptually-correct number comparisons.
   * Example: Int8(-1) != UInt8(255)
 */
@@ -484,8 +484,8 @@ struct EqualsOp {
 };
 
 template <>
-struct EqualsOp<DateTimeValue, DateTimeValue> {
-    static UInt8 apply(const Int128& a, const Int128& b) {
+struct EqualsOp<VecDateTimeValue, VecDateTimeValue> {
+    static UInt8 apply(const Int64& a, const Int64& b) {
         return a == b;
     }
 };
@@ -497,8 +497,8 @@ struct NotEqualsOp {
 };
 
 template <>
-struct NotEqualsOp<DateTimeValue, DateTimeValue> {
-    static UInt8 apply(const Int128& a, const Int128& b) {
+struct NotEqualsOp<VecDateTimeValue, VecDateTimeValue> {
+    static UInt8 apply(const Int64& a, const Int64& b) {
         return a != b;
     }
 };
@@ -513,9 +513,9 @@ struct LessOp {
 };
 
 template <>
-struct LessOp<DateTimeValue, DateTimeValue> {
-    static UInt8 apply(Int128 a, Int128 b) {
-        return binary_cast<Int128, DateTimeValue>(a) < binary_cast<Int128, DateTimeValue>(b);
+struct LessOp<VecDateTimeValue, VecDateTimeValue> {
+    static UInt8 apply(Int64 a, Int64 b) {
+        return binary_cast<Int64, VecDateTimeValue>(a) < binary_cast<Int64, VecDateTimeValue>(b);
     }
 };
 
@@ -526,9 +526,9 @@ struct GreaterOp {
 };
 
 template <>
-struct GreaterOp<DateTimeValue, DateTimeValue> {
-    static UInt8 apply(Int128 a, Int128 b) {
-        return binary_cast<Int128, DateTimeValue>(a) > binary_cast<Int128, DateTimeValue>(b);
+struct GreaterOp<VecDateTimeValue, VecDateTimeValue> {
+    static UInt8 apply(Int64 a, Int64 b) {
+        return binary_cast<Int64, VecDateTimeValue>(a) > binary_cast<Int64, VecDateTimeValue>(b);
     }
 };
 
@@ -542,9 +542,9 @@ struct LessOrEqualsOp {
 };
 
 template <>
-struct LessOrEqualsOp<DateTimeValue, DateTimeValue> {
-    static UInt8 apply(Int128 a, Int128 b) {
-        return binary_cast<Int128, DateTimeValue>(a) <= binary_cast<Int128, DateTimeValue>(b);
+struct LessOrEqualsOp<VecDateTimeValue, VecDateTimeValue> {
+    static UInt8 apply(Int64 a, Int64 b) {
+        return binary_cast<Int64, VecDateTimeValue>(a) <= binary_cast<Int64, VecDateTimeValue>(b);
     }
 };
 
@@ -555,9 +555,9 @@ struct GreaterOrEqualsOp {
 };
 
 template <>
-struct GreaterOrEqualsOp<DateTimeValue, DateTimeValue> {
-    static UInt8 apply(Int128 a, Int128 b) {
-        return binary_cast<Int128, DateTimeValue>(a) >= binary_cast<Int128, DateTimeValue>(b);
+struct GreaterOrEqualsOp<VecDateTimeValue, VecDateTimeValue> {
+    static UInt8 apply(Int64 a, Int64 b) {
+        return binary_cast<Int64, VecDateTimeValue>(a) >= binary_cast<Int64, VecDateTimeValue>(b);
     }
 };
 

--- a/be/src/vec/data_types/data_type_date.cpp
+++ b/be/src/vec/data_types/data_type_date.cpp
@@ -20,16 +20,16 @@
 #include "runtime/datetime_value.h"
 #include "vec/columns/columns_number.h"
 #include "util/binary_cast.hpp"
-
+#include "vec/runtime/vdatetime_value.h"
 namespace doris::vectorized {
 bool DataTypeDate::equals(const IDataType& rhs) const {
     return typeid(rhs) == typeid(*this);
 }
 
 std::string DataTypeDate::to_string(const IColumn& column, size_t row_num) const {
-    Int128 int_val = assert_cast<const ColumnInt128&>(*column.convert_to_full_column_if_const().get())
+    Int64 int_val = assert_cast<const ColumnInt64&>(*column.convert_to_full_column_if_const().get())
                              .get_data()[row_num];
-    doris::DateTimeValue value = binary_cast<Int128, doris::DateTimeValue>(int_val);
+    doris::vectorized::VecDateTimeValue value = binary_cast<Int64, doris::vectorized::VecDateTimeValue>(int_val);
     std::stringstream ss;
     // Year
     uint32_t temp = value.year() / 100;
@@ -44,9 +44,9 @@ std::string DataTypeDate::to_string(const IColumn& column, size_t row_num) const
 }
 
 void DataTypeDate::to_string(const IColumn & column, size_t row_num, BufferWritable & ostr) const {
-    Int128 int_val = assert_cast<const ColumnInt128&>(*column.convert_to_full_column_if_const().get())
+    Int64 int_val = assert_cast<const ColumnInt64&>(*column.convert_to_full_column_if_const().get())
                              .get_data()[row_num];
-    doris::DateTimeValue value = binary_cast<Int128, doris::DateTimeValue>(int_val);
+    doris::vectorized::VecDateTimeValue value = binary_cast<Int64, doris::vectorized::VecDateTimeValue>(int_val);
 
     char buf[64];
     char* pos = value.to_string(buf);
@@ -54,10 +54,10 @@ void DataTypeDate::to_string(const IColumn & column, size_t row_num, BufferWrita
     ostr.write(buf, pos - buf - 1);
 }
 
-void DataTypeDate::cast_to_date(Int128 &x) {
-    auto value = binary_cast<Int128, DateTimeValue>(x);
+void DataTypeDate::cast_to_date(Int64& x) {
+    auto value = binary_cast<Int64, VecDateTimeValue>(x);
     value.cast_to_date();
-    x = binary_cast<DateTimeValue, Int128>(value);
+    x = binary_cast<VecDateTimeValue, Int64>(value);
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/data_types/data_type_date.h
+++ b/be/src/vec/data_types/data_type_date.h
@@ -21,7 +21,7 @@
 
 namespace doris::vectorized {
 
-class DataTypeDate final : public DataTypeNumberBase<Int128> {
+class DataTypeDate final : public DataTypeNumberBase<Int64> {
 public:
     TypeIndex get_type_id() const override { return TypeIndex::Date; }
     const char* get_family_name() const override { return "Date"; }
@@ -33,7 +33,7 @@ public:
     std::string to_string(const IColumn& column, size_t row_num) const;
     void to_string(const IColumn &column, size_t row_num, BufferWritable &ostr) const override;
 
-    static void cast_to_date(Int128& x);
+    static void cast_to_date(Int64& x);
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/data_types/data_type_date_time.h
+++ b/be/src/vec/data_types/data_type_date_time.h
@@ -44,7 +44,7 @@ namespace doris::vectorized {
   * Server time zone is the time zone specified in 'timezone' parameter in configuration file,
   *  or system time zone at the moment of server startup.
   */
-class DataTypeDateTime final : public DataTypeNumberBase<Int128> {
+class DataTypeDateTime final : public DataTypeNumberBase<Int64> {
 public:
     DataTypeDateTime();
 
@@ -61,7 +61,7 @@ public:
 
     void to_string(const IColumn &column, size_t row_num, BufferWritable &ostr) const override;
 
-    static void cast_to_date_time(Int128 &x);
+    static void cast_to_date_time(Int64& x);
 };
 
 template <typename DataType>

--- a/be/src/vec/exec/volap_scanner.cpp
+++ b/be/src/vec/exec/volap_scanner.cpp
@@ -26,7 +26,7 @@
 #include "vec/exec/volap_scan_node.h"
 #include "vec/exprs/vexpr_context.h"
 #include "vec/olap/block_reader.h"
-
+#include "vec/runtime/vdatetime_value.h"
 namespace doris::vectorized {
 
 VOlapScanner::VOlapScanner(RuntimeState* runtime_state, VOlapScanNode* parent, bool aggregation,
@@ -187,8 +187,8 @@ void VOlapScanner::_convert_row_to_block(std::vector<vectorized::MutableColumnPt
         }
         case TYPE_DATETIME: {
             uint64_t value = *reinterpret_cast<uint64_t*>(ptr);
-            DateTimeValue data(value);
-            assert_cast<ColumnVector<Int128>*>(column_ptr)
+            VecDateTimeValue data(value);
+            assert_cast<ColumnVector<Int64>*>(column_ptr)
                     ->insert_data(reinterpret_cast<char*>(&data), 0);
             break;
         }
@@ -199,9 +199,9 @@ void VOlapScanner::_convert_row_to_block(std::vector<vectorized::MutableColumnPt
             value |= *(unsigned char*)(ptr + 1);
             value <<= 8;
             value |= *(unsigned char*)(ptr);
-            DateTimeValue date;
+            VecDateTimeValue date;
             date.from_olap_date(value);
-            assert_cast<ColumnVector<Int128>*>(column_ptr)
+            assert_cast<ColumnVector<Int64>*>(column_ptr)
                     ->insert_data(reinterpret_cast<char*>(&date), 0);
             break;
         }

--- a/be/src/vec/exprs/vliteral.cpp
+++ b/be/src/vec/exprs/vliteral.cpp
@@ -22,7 +22,7 @@
 #include "util/string_parser.hpp"
 #include "vec/core/field.h"
 #include "vec/data_types/data_type_nullable.h"
-
+#include "vec/runtime/vdatetime_value.h"
 namespace doris::vectorized {
 VLiteral::VLiteral(const TExprNode& node) : VExpr(node) {
     Field field;
@@ -84,17 +84,17 @@ VLiteral::VLiteral(const TExprNode& node) : VExpr(node) {
                 break;
             }
             case TYPE_DATE: {
-                DateTimeValue value;
+                VecDateTimeValue value;
                 value.from_date_str(node.date_literal.value.c_str(), node.date_literal.value.size());
                 value.cast_to_date();
-                field = Int128(*reinterpret_cast<__int128_t*>(&value));
+                field = Int64(*reinterpret_cast<__int64_t*>(&value));
                 break;
             }
             case TYPE_DATETIME: {
-                DateTimeValue value;
+                VecDateTimeValue value;
                 value.from_date_str(node.date_literal.value.c_str(), node.date_literal.value.size());
                 value.to_datetime();
-                field = Int128(*reinterpret_cast<__int128_t*>(&value));
+                field = Int64(*reinterpret_cast<__int64_t*>(&value));
                 break;
             }
             case TYPE_STRING:

--- a/be/src/vec/functions/date_time_transforms.h
+++ b/be/src/vec/functions/date_time_transforms.h
@@ -25,14 +25,14 @@
 #include "vec/common/exception.h"
 #include "vec/core/types.h"
 #include "vec/functions/function_helpers.h"
-
+#include "vec/runtime/vdatetime_value.h"
 namespace doris::vectorized {
 
 #define TIME_FUNCTION_IMPL(CLASS, UNIT, FUNCTION)                     \
     struct CLASS {                                                    \
         static constexpr auto name = #UNIT;                           \
-        static inline auto execute(const Int128& t, bool& is_null) {  \
-            const auto& date_time_value = (doris::DateTimeValue&)(t); \
+        static inline auto execute(const Int64& t, bool& is_null) {  \
+            const auto& date_time_value = (doris::vectorized::VecDateTimeValue&)(t); \
             is_null = !date_time_value.is_valid_date();               \
             return date_time_value.FUNCTION;                          \
         }                                                             \
@@ -43,6 +43,7 @@ namespace doris::vectorized {
 TO_TIME_FUNCTION(ToYearImpl, year);
 TO_TIME_FUNCTION(ToQuarterImpl, quarter);
 TO_TIME_FUNCTION(ToMonthImpl, month);
+TO_TIME_FUNCTION(ToWeekImpl, week);
 TO_TIME_FUNCTION(ToDayImpl, day);
 TO_TIME_FUNCTION(ToHourImpl, hour);
 TO_TIME_FUNCTION(ToMinuteImpl, minute);
@@ -53,15 +54,15 @@ TIME_FUNCTION_IMPL(DayOfYearImpl, dayofyear, day_of_year());
 TIME_FUNCTION_IMPL(DayOfMonthImpl, dayofmonth, day());
 TIME_FUNCTION_IMPL(DayOfWeekImpl, dayofweek, day_of_week());
 TIME_FUNCTION_IMPL(ToDaysImpl, to_days, daynr());
-
+TIME_FUNCTION_IMPL(ToYearWeekImpl, yearweek, year_week(mysql_week_mode(0)));
 struct ToDateImpl {
     static constexpr auto name = "to_date";
 
-    static inline auto execute(const Int128& t, bool& is_null) {
-        auto dt = binary_cast<Int128, doris::DateTimeValue>(t);
+    static inline auto execute(const Int64& t, bool& is_null) {
+        auto dt = binary_cast<Int64, doris::vectorized::VecDateTimeValue>(t);
         is_null = !dt.is_valid_date();
         dt.cast_to_date();
-        return binary_cast<doris::DateTimeValue, Int128>(dt);
+        return binary_cast<doris::vectorized::VecDateTimeValue, Int64>(dt);
     }
 };
 struct DateImpl : public ToDateImpl {
@@ -72,16 +73,16 @@ struct DateImpl : public ToDateImpl {
 // this function
 struct TimeStampImpl {
     static constexpr auto name = "timestamp";
-    static inline auto execute(const Int128& t, bool& is_null) { return t; }
+    static inline auto execute(const Int64& t, bool& is_null) { return t; }
 };
 
 struct UnixTimeStampImpl {
     static constexpr auto name = "unix_timestamp";
-    static inline int execute(const Int128& t, bool& is_null) {
+    static inline int execute(const Int64& t, bool& is_null) {
         // TODO: use default time zone, slowly and incorrect, just for test use
         static cctz::time_zone time_zone = cctz::fixed_time_zone(cctz::seconds(8 * 60 * 60));
 
-        const auto& dt = (doris::DateTimeValue&)(t);
+        const auto& dt = (doris::vectorized::VecDateTimeValue&)(t);
         is_null = !dt.is_valid_date();
         int64_t timestamp = 0;
         dt.unix_timestamp(&timestamp, time_zone);
@@ -94,7 +95,7 @@ struct DayNameImpl {
     static constexpr auto name = "dayname";
     static constexpr auto max_size = MAX_DAY_NAME_LEN;
 
-    static inline auto execute(const DateTimeValue& dt, ColumnString::Chars& res_data,
+    static inline auto execute(const VecDateTimeValue& dt, ColumnString::Chars& res_data,
                                size_t& offset, bool& is_null) {
         const auto* day_name = dt.day_name();
         is_null = !dt.is_valid_date();
@@ -115,7 +116,7 @@ struct MonthNameImpl {
     static constexpr auto name = "monthname";
     static constexpr auto max_size = MAX_MONTH_NAME_LEN;
 
-    static inline auto execute(const DateTimeValue& dt, ColumnString::Chars& res_data,
+    static inline auto execute(const VecDateTimeValue& dt, ColumnString::Chars& res_data,
                                size_t& offset, bool& is_null) {
         const auto* month_name = dt.month_name();
         is_null = !dt.is_valid_date();
@@ -133,13 +134,13 @@ struct MonthNameImpl {
 };
 
 struct DateFormatImpl {
-    using FromType = Int128;
+    using FromType = Int64;
 
     static constexpr auto name = "date_format";
 
-    static inline auto execute(const Int128& t, StringRef format, ColumnString::Chars& res_data,
+    static inline auto execute(const Int64& t, StringRef format, ColumnString::Chars& res_data,
                                size_t& offset) {
-        const auto& dt = (DateTimeValue&)t;
+        const auto& dt = (VecDateTimeValue&)t;
         if (format.size > 128) {
             offset += 1;
             res_data.emplace_back(0);
@@ -169,7 +170,7 @@ struct FromUnixTimeImpl {
         // TODO: use default time zone, slowly and incorrect, just for test use
         static cctz::time_zone time_zone = cctz::fixed_time_zone(cctz::seconds(8 * 60 * 60));
 
-        DateTimeValue dt;
+        VecDateTimeValue dt;
         if (format.size > 128 || val < 0 || val > INT_MAX || !dt.from_unixtime(val, time_zone)) {
             offset += 1;
             res_data.emplace_back(0);
@@ -192,7 +193,7 @@ struct FromUnixTimeImpl {
 
 template <typename Transform>
 struct TransformerToStringOneArgument {
-    static void vector(const PaddedPODArray<Int128>& ts, ColumnString::Chars& res_data,
+    static void vector(const PaddedPODArray<Int64>& ts, ColumnString::Chars& res_data,
                        ColumnString::Offsets& res_offsets, NullMap& null_map) {
         const auto len = ts.size();
         res_data.resize(len * Transform::max_size);
@@ -202,7 +203,7 @@ struct TransformerToStringOneArgument {
         size_t offset = 0;
         for (int i = 0; i < len; ++i) {
             const auto& t = ts[i];
-            const auto& date_time_value = reinterpret_cast<const DateTimeValue&>(t);
+            const auto& date_time_value = reinterpret_cast<const VecDateTimeValue&>(t);
             res_offsets[i] = Transform::execute(date_time_value, res_data, offset,
                     reinterpret_cast<bool&>(null_map[i]));
         }

--- a/be/src/vec/functions/function_date_or_datetime_to_something.h
+++ b/be/src/vec/functions/function_date_or_datetime_to_something.h
@@ -80,7 +80,7 @@ public:
         const IDataType* from_type = block.get_by_position(arguments[0]).type.get();
         WhichDataType which(from_type);
 
-        return DateTimeTransformImpl<Int128, typename ToDataType::FieldType, Transform>::execute(
+        return DateTimeTransformImpl<Int64, typename ToDataType::FieldType, Transform>::execute(
                 block, arguments, result, input_rows_count);
     }
 

--- a/be/src/vec/functions/function_date_or_datetime_to_string.h
+++ b/be/src/vec/functions/function_date_or_datetime_to_string.h
@@ -43,7 +43,7 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) override {
         const ColumnPtr source_col = block.get_by_position(arguments[0]).column;
-        const auto* sources = check_and_get_column<ColumnVector<Int128>>(source_col.get());
+        const auto* sources = check_and_get_column<ColumnVector<Int64>>(source_col.get());
         auto col_res = ColumnString::create();
         auto null_map = ColumnVector<UInt8>::create();
         if (sources) {

--- a/be/src/vec/functions/time_of_function.cpp
+++ b/be/src/vec/functions/time_of_function.cpp
@@ -26,11 +26,12 @@ using FunctionWeekOfYear = FunctionDateOrDateTimeToSomething<DataTypeInt32, Week
 using FunctionDayOfYear = FunctionDateOrDateTimeToSomething<DataTypeInt32, DayOfYearImpl>;
 using FunctionDayOfWeek = FunctionDateOrDateTimeToSomething<DataTypeInt32, DayOfWeekImpl>;
 using FunctionDayOfMonth = FunctionDateOrDateTimeToSomething<DataTypeInt32, DayOfMonthImpl>;
-
+using FunctionYearWeek = FunctionDateOrDateTimeToSomething<DataTypeInt32, ToYearWeekImpl>;
 void register_function_time_of_fuction(SimpleFunctionFactory& factory) {
     factory.register_function<FunctionDayOfWeek>();
     factory.register_function<FunctionDayOfMonth>();
     factory.register_function<FunctionDayOfYear>();
     factory.register_function<FunctionWeekOfYear>();
+    factory.register_function<FunctionYearWeek>();
 }
 } // namespace doris::vectorized

--- a/be/src/vec/functions/to_time_function.cpp
+++ b/be/src/vec/functions/to_time_function.cpp
@@ -27,6 +27,7 @@ using FunctionYear = FunctionDateOrDateTimeToSomething<DataTypeInt32, ToYearImpl
 using FunctionQuarter = FunctionDateOrDateTimeToSomething<DataTypeInt32, ToQuarterImpl>;
 using FunctionMonth = FunctionDateOrDateTimeToSomething<DataTypeInt32, ToMonthImpl>;
 using FunctionDay = FunctionDateOrDateTimeToSomething<DataTypeInt32, ToDayImpl>;
+using FunctionWeek = FunctionDateOrDateTimeToSomething<DataTypeInt32, ToWeekImpl>;
 using FunctionHour = FunctionDateOrDateTimeToSomething<DataTypeInt32, ToHourImpl>;
 using FunctionMinute = FunctionDateOrDateTimeToSomething<DataTypeInt32, ToMinuteImpl>;
 using FunctionSecond = FunctionDateOrDateTimeToSomething<DataTypeInt32, ToSecondImpl>;
@@ -41,6 +42,7 @@ void register_function_to_time_fuction(SimpleFunctionFactory& factory) {
     factory.register_function<FunctionMinute>();
     factory.register_function<FunctionHour>();
     factory.register_function<FunctionDay>();
+    factory.register_function<FunctionWeek>();
     factory.register_function<FunctionMonth>();
     factory.register_function<FunctionYear>();
     factory.register_function<FunctionQuarter>();

--- a/be/src/vec/io/io_helper.h
+++ b/be/src/vec/io/io_helper.h
@@ -31,6 +31,7 @@
 #include "vec/core/types.h"
 #include "vec/io/reader_buffer.h"
 #include "vec/io/var_int.h"
+#include "vec/runtime/vdatetime_value.h"
 
 #define DEFAULT_MAX_STRING_SIZE (1ULL << 30)
 #define WRITE_HELPERS_MAX_INT_WIDTH 40U
@@ -339,26 +340,26 @@ bool read_int_text_impl(T& x, ReadBuffer& buf) {
 
 template <typename T>
 bool read_datetime_text_impl(T& x, ReadBuffer& buf) {
-    static_assert(std::is_same_v<Int128, T>);
-    auto dv = binary_cast<Int128, DateTimeValue>(x);
+    static_assert(std::is_same_v<Int64, T>);
+    auto dv = binary_cast<Int64, VecDateTimeValue>(x);
     auto ans = dv.from_date_str(buf.position(), buf.count());
 
     // only to match the is_all_read() check to prevent return null
     buf.position() = buf.end();
-    x = binary_cast<DateTimeValue, Int128>(dv);
+    x = binary_cast<VecDateTimeValue, Int64>(dv);
     return ans;
 }
 
 template <typename T>
 bool read_date_text_impl(T& x, ReadBuffer& buf) {
-    static_assert(std::is_same_v<Int128, T>);
-    auto dv = binary_cast<Int128, DateTimeValue>(x);
+    static_assert(std::is_same_v<Int64, T>);
+    auto dv = binary_cast<Int64, VecDateTimeValue>(x);
     auto ans = dv.from_date_str(buf.position(), buf.count());
     dv.cast_to_date();
 
     // only to match the is_all_read() check to prevent return null
     buf.position() = buf.end();
-    x = binary_cast<DateTimeValue, Int128>(dv);
+    x = binary_cast<VecDateTimeValue, Int64>(dv);
     return ans;
 }
 

--- a/be/src/vec/runtime/vdatetime_value.cpp
+++ b/be/src/vec/runtime/vdatetime_value.cpp
@@ -1,0 +1,1602 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/runtime/vdatetime_value.h"
+
+#include <ctype.h>
+#include <string.h>
+#include <time.h>
+
+#include <limits>
+#include <sstream>
+
+#include "common/logging.h"
+#include "util/timezone_utils.h"
+
+namespace doris::vectorized {
+
+static int s_days_in_month[13] = {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+
+static const char* s_ab_month_name[] = {"",    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", NULL};
+
+static const char* s_ab_day_name[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun", NULL};
+
+uint8_t mysql_week_mode(uint32_t mode) {
+    mode &= 7;
+    if (!(mode & WEEK_MONDAY_FIRST)) {
+        mode ^= WEEK_FIRST_WEEKDAY;
+    }
+    return mode;
+}
+
+static bool is_leap(uint32_t year) {
+    return ((year % 4) == 0) && ((year % 100 != 0) || ((year % 400) == 0 && year));
+}
+
+static uint32_t calc_days_in_year(uint32_t year) {
+    return is_leap(year) ? 366 : 365;
+}
+
+RE2 VecDateTimeValue::time_zone_offset_format_reg("^[+-]{1}\\d{2}\\:\\d{2}$");
+
+bool VecDateTimeValue::check_range(uint32_t year, uint32_t month, uint32_t day, uint32_t hour,
+        uint32_t minute, uint32_t second, uint16_t type) {
+    bool time = hour > (type == TIME_TIME ? TIME_MAX_HOUR : 23) || minute > 59 || second > 59;
+    return time || check_date(year, month, day);
+}
+
+bool VecDateTimeValue::check_date(uint32_t year, uint32_t month, uint32_t day) {
+    if (month != 0 && month <= 12 && day > s_days_in_month[month]) {
+        // Feb 29 in leap year is valid.
+        if (!(month == 2 && day == 29 && is_leap(year))) return true;
+    }
+    return year > 9999 || month > 12 || day > 31;
+}
+
+// The interval format is that with no delimiters
+// YYYY-MM-DD HH-MM-DD.FFFFFF AM in default format
+// 0    1  2  3  4  5  6      7
+bool VecDateTimeValue::from_date_str(const char* date_str, int len) {
+    const char* ptr = date_str;
+    const char* end = date_str + len;
+    // ONLY 2, 6 can follow by a sapce
+    const static int allow_space_mask = 4 | 64;
+    const static int MAX_DATE_PARTS = 8;
+    uint32_t date_val[MAX_DATE_PARTS];
+    int32_t date_len[MAX_DATE_PARTS];
+
+    _neg = false;
+    // Skip space character
+    while (ptr < end && isspace(*ptr)) {
+        ptr++;
+    }
+    if (ptr == end || !isdigit(*ptr)) {
+        return false;
+    }
+    // Fix year length
+    const char* pos = ptr;
+    while (pos < end && (isdigit(*pos) || *pos == 'T')) {
+        pos++;
+    }
+    int year_len = 4;
+    int digits = pos - ptr;
+    bool is_interval_format = false;
+
+    // Compatible with MySQL. Shit!!!
+    // For YYYYMMDD/YYYYMMDDHHMMSS is 4 digits years
+    if (pos == end || *pos == '.') {
+        if (digits == 4 || digits == 8 || digits >= 14) {
+            year_len = 4;
+        } else {
+            year_len = 2;
+        }
+        is_interval_format = true;
+    }
+
+    int field_idx = 0;
+    int field_len = year_len;
+    while (ptr < end && isdigit(*ptr) && field_idx < MAX_DATE_PARTS - 1) {
+        const char* start = ptr;
+        int temp_val = 0;
+        bool scan_to_delim = (!is_interval_format) && (field_idx != 6);
+        while (ptr < end && isdigit(*ptr) && (scan_to_delim || field_len--)) {
+            temp_val = temp_val * 10 + (*ptr++ - '0');
+        }
+        // Imposible
+        if (temp_val > 999999L) {
+            return false;
+        }
+        date_val[field_idx] = temp_val;
+        date_len[field_idx] = ptr - start;
+        field_len = 2;
+
+        if (ptr == end) {
+            field_idx++;
+            break;
+        }
+        if (field_idx == 2 && *ptr == 'T') {
+            // YYYYMMDDTHHMMDD, skip 'T' and continue
+            ptr++;
+            field_idx++;
+            continue;
+        }
+
+        // Second part
+        if (field_idx == 5) {
+            if (*ptr == '.') {
+                ptr++;
+                field_len = 6;
+            } else if (isdigit(*ptr)) {
+                field_idx++;
+                break;
+            }
+            field_idx++;
+            continue;
+        }
+        // escape separator
+        while (ptr < end && (ispunct(*ptr) || isspace(*ptr))) {
+            if (isspace(*ptr)) {
+                if (((1 << field_idx) & allow_space_mask) == 0) {
+                    return false;
+                }
+            }
+            ptr++;
+        }
+        field_idx++;
+    }
+    int num_field = field_idx;
+    if (num_field <= 3) {
+        _type = TIME_DATE;
+    } else {
+        _type = TIME_DATETIME;
+    }
+    if (!is_interval_format) {
+        year_len = date_len[0];
+    }
+    for (; field_idx < MAX_DATE_PARTS; ++field_idx) {
+        date_len[field_idx] = 0;
+        date_val[field_idx] = 0;
+    }
+
+    if (year_len == 2) {
+        if (date_val[0] < YY_PART_YEAR) {
+            date_val[0] += 2000;
+        } else {
+            date_val[0] += 1900;
+        }
+    }
+
+    if (num_field < 3) return false;
+    return check_range_and_set_time(date_val[0], date_val[1], date_val[2],
+            date_val[3], date_val[4], date_val[5], _type);
+}
+
+// [0, 101) invalid
+// [101, (YY_PART_YEAR - 1) * 10000 + 1231] for two digits year 2000 ~ 2069
+// [(YY_PART_YEAR - 1) * 10000 + 1231, YY_PART_YEAR * 10000L + 101) invalid
+// [YY_PART_YEAR * 10000L + 101, 991231] for two digits year 1970 ~1999
+// (991231, 10000101) invalid, because support 1000-01-01
+// [10000101, 99991231] for four digits year date value.
+// (99991231, 101000000) invalid, NOTE below this is datetime vaule hh:mm:ss must exist.
+// [101000000, (YY_PART_YEAR - 1)##1231235959] two digits year datetime value
+// ((YY_PART_YEAR - 1)##1231235959, YY_PART_YEAR##0101000000) invalid
+// ((YY_PART_YEAR)##1231235959, 99991231235959] two digits year datetime value 1970 ~ 1999
+// (999991231235959, ~) valid
+int64_t VecDateTimeValue::standardize_timevalue(int64_t value) {
+    _type = TIME_DATE;
+    if (value <= 0) {
+        return 0;
+    }
+    if (value >= 10000101000000L) {
+        // 9999-99-99 99:99:99
+        if (value > 99999999999999L) {
+            return 0;
+        }
+
+        // between 1000-01-01 00:00:00L and 9999-99-99 99:99:99
+        // all digits exist.
+        _type = TIME_DATETIME;
+        return value;
+    }
+    // 2000-01-01
+    if (value < 101) {
+        return 0;
+    }
+    // two digits  year. 2000 ~ 2069
+    if (value <= (YY_PART_YEAR - 1) * 10000L + 1231L) {
+        return (value + 20000000L) * 1000000L;
+    }
+    // two digits year, invalid date
+    if (value < YY_PART_YEAR * 10000L + 101) {
+        return 0;
+    }
+    // two digits year. 1970 ~ 1999
+    if (value <= 991231L) {
+        return (value + 19000000L) * 1000000L;
+    }
+    // TODO(zhaochun): Don't allow year betwen 1000-01-01
+    if (value < 10000101) {
+        return 0;
+    }
+    // four digits years without hour.
+    if (value <= 99991231L) {
+        return value * 1000000L;
+    }
+    // below 0000-01-01
+    if (value < 101000000) {
+        return 0;
+    }
+
+    // below is with datetime, must have hh:mm:ss
+    _type = TIME_DATETIME;
+    // 2000 ~ 2069
+    if (value <= (YY_PART_YEAR - 1) * 10000000000L + 1231235959L) {
+        return value + 20000000000000L;
+    }
+    if (value < YY_PART_YEAR * 10000000000L + 101000000L) {
+        return 0;
+    }
+    // 1970 ~ 1999
+    if (value <= 991231235959L) {
+        return value + 19000000000000L;
+    }
+    return value;
+}
+
+bool VecDateTimeValue::from_date_int64(int64_t value) {
+    _neg = false;
+    value = standardize_timevalue(value);
+    if (value <= 0) {
+        return false;
+    }
+    uint64_t date = value / 1000000;
+    uint64_t time = value % 1000000;
+
+    auto [year, month, day, hour, minute, second] = std::tuple{0,0,0,0,0,0};
+    year = date / 10000;
+    date %= 10000;
+    month = date / 100;
+    day = date % 100;
+    hour = time / 10000;
+    time %= 10000;
+    minute = time / 100;
+    second = time % 100;
+
+    return check_range_and_set_time(year, month, day, hour, minute, second, _type);
+}
+
+void VecDateTimeValue::set_zero(int type) {
+    memset(this, 0, sizeof(*this));
+    _type = type;
+}
+
+void VecDateTimeValue::set_type(int type) {
+    _type = type;
+}
+
+void VecDateTimeValue::set_max_time(bool neg) {
+    set_zero(TIME_TIME);
+    _hour = TIME_MAX_HOUR;
+    _minute = TIME_MAX_MINUTE;
+    _second = TIME_MAX_SECOND;
+    _neg = neg;
+}
+
+bool VecDateTimeValue::from_time_int64(int64_t value) {
+    _type = TIME_TIME;
+    if (value > TIME_MAX_VALUE) {
+        // 0001-01-01 00:00:00 to convert to a datetime
+        if (value > 10000000000L) {
+            if (from_date_int64(value)) {
+                return true;
+            }
+        }
+        set_max_time(false);
+        return false;
+    } else if (value < -1 * TIME_MAX_VALUE) {
+        set_max_time(true);
+        return false;
+    }
+    if (value < 0) {
+        _neg = 1;
+        value = -value;
+    }
+    _hour = value / 10000;
+    value %= 10000;
+    _minute = value / 100;
+    if (_minute > TIME_MAX_MINUTE) {
+        return false;
+    }
+    _second = value % 100;
+    if (_second > TIME_MAX_SECOND) {
+        return false;
+    }
+    return true;
+}
+
+char* VecDateTimeValue::append_date_buffer(char* to) const {
+    uint32_t temp;
+    // Year
+    temp = _year / 100;
+    *to++ = (char)('0' + (temp / 10));
+    *to++ = (char)('0' + (temp % 10));
+    temp = _year % 100;
+    *to++ = (char)('0' + (temp / 10));
+    *to++ = (char)('0' + (temp % 10));
+    *to++ = '-';
+    // Month
+    *to++ = (char)('0' + (_month / 10));
+    *to++ = (char)('0' + (_month % 10));
+    *to++ = '-';
+    // Day
+    *to++ = (char)('0' + (_day / 10));
+    *to++ = (char)('0' + (_day % 10));
+    return to;
+}
+
+char* VecDateTimeValue::append_time_buffer(char* to) const {
+    if (_neg) {
+        *to++ = '-';
+    }
+    // Hour
+    uint32_t temp = _hour;
+    if (temp >= 100) {
+        *to++ = (char)('0' + (temp / 100));
+        temp %= 100;
+    }
+    *to++ = (char)('0' + (temp / 10));
+    *to++ = (char)('0' + (temp % 10));
+    *to++ = ':';
+    // Minute
+    *to++ = (char)('0' + (_minute / 10));
+    *to++ = (char)('0' + (_minute % 10));
+    *to++ = ':';
+    /* Second */
+    *to++ = (char)('0' + (_second / 10));
+    *to++ = (char)('0' + (_second % 10));
+    return to;
+}
+
+char* VecDateTimeValue::to_datetime_buffer(char* to) const {
+    to = append_date_buffer(to);
+    *to++ = ' ';
+    return append_time_buffer(to);
+}
+
+char* VecDateTimeValue::to_date_buffer(char* to) const {
+    return append_date_buffer(to);
+}
+
+char* VecDateTimeValue::to_time_buffer(char* to) const {
+    return append_time_buffer(to);
+}
+
+int32_t VecDateTimeValue::to_buffer(char* buffer) const {
+    switch (_type) {
+        case TIME_TIME:
+            return to_time_buffer(buffer) - buffer;
+        case TIME_DATE:
+            return to_date_buffer(buffer) - buffer;
+        case TIME_DATETIME:
+            return to_datetime_buffer(buffer) - buffer;
+        default:
+            break;
+    }
+    return 0;
+}
+
+char* VecDateTimeValue::to_string(char* to) const {
+    int len = to_buffer(to);
+    *(to + len) = '\0';
+    return to + len + 1;
+}
+
+int64_t VecDateTimeValue::to_datetime_int64() const {
+    return (_year * 10000L + _month * 100 + _day) * 1000000L + _hour * 10000 + _minute * 100 + _second;
+}
+
+int64_t VecDateTimeValue::to_date_int64() const {
+    return _year * 10000 + _month * 100 + _day;
+}
+
+int64_t VecDateTimeValue::to_time_int64() const {
+    int sign = _neg == 0 ? 1 : -1;
+    return sign * (_hour * 10000 + _minute * 100 + _second);
+}
+
+int64_t VecDateTimeValue::to_int64() const {
+    switch (_type) {
+    case TIME_TIME:
+        return to_time_int64();
+    case TIME_DATE:
+        return to_date_int64();
+    case TIME_DATETIME:
+        return to_datetime_int64();
+    default:
+        return 0;
+    }
+}
+
+bool VecDateTimeValue::get_date_from_daynr(uint64_t daynr) {
+    if (daynr <= 0 || daynr > DATE_MAX_DAYNR) {
+        return false;
+    }
+
+    auto [year, month, day] = std::tuple{0, 0, 0};
+    year = daynr / 365;
+    uint32_t days_befor_year = 0;
+    while (daynr < (days_befor_year = calc_daynr(year, 1, 1))) {
+        year--;
+    }
+    uint32_t days_of_year = daynr - days_befor_year + 1;
+    int leap_day = 0;
+    if (is_leap(year)) {
+        if (days_of_year > 31 + 28) {
+            days_of_year--;
+            if (days_of_year == 31 + 28) {
+                leap_day = 1;
+            }
+        }
+    }
+    month = 1;
+    while (days_of_year > s_days_in_month[month]) {
+        days_of_year -= s_days_in_month[month];
+        month++;
+    }
+    day = days_of_year + leap_day;
+
+    if (check_range(year, month, day, 0, 0, 0, _type)) {
+        return false;
+    }
+    set_time(year, month, day, _hour, _minute, _second);
+    return true;
+}
+
+bool VecDateTimeValue::from_date_daynr(uint64_t daynr) {
+    _neg = false;
+    if (!get_date_from_daynr(daynr)) {
+        return false;
+    }
+    _hour = 0;
+    _minute = 0;
+    _second = 0;
+    _type = TIME_DATE;
+    return true;
+}
+
+// Following code is stolen from MySQL.
+uint64_t VecDateTimeValue::calc_daynr(uint32_t year, uint32_t month, uint32_t day) {
+    uint64_t delsum = 0;
+    int y = year;
+
+    if (year == 0 && month == 0) {
+        return 0;
+    }
+
+    /* Cast to int to be able to handle month == 0 */
+    delsum = 365 * y + 31 * (month - 1) + day;
+    if (month <= 2) {
+        // No leap year
+        y--;
+    } else {
+        // This is great!!!
+        // 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
+        // 0, 0, 3, 3, 4, 4, 5, 5, 5,  6,  7,  8
+        delsum -= (month * 4 + 23) / 10;
+    }
+    // Every 400 year has 97 leap year, 100, 200, 300 are not leap year.
+    return delsum + y / 4 - y / 100 + y / 400;
+}
+
+static char* int_to_str(uint64_t val, char* to) {
+    char buf[64];
+    char* ptr = buf;
+    // Use do/while for 0 value
+    do {
+        *ptr++ = '0' + (val % 10);
+        val /= 10;
+    } while (val);
+
+    while (ptr > buf) {
+        *to++ = *--ptr;
+    }
+
+    return to;
+}
+
+static char* append_string(const char* from, char* to) {
+    while (*from) {
+        *to++ = *from++;
+    }
+    return to;
+}
+
+static char* append_with_prefix(const char* str, int str_len, char prefix, int full_len, char* to) {
+    int len = (str_len > full_len) ? str_len : full_len;
+    len -= str_len;
+    while (len-- > 0) {
+        // push prefix;
+        *to++ = prefix;
+    }
+    while (str_len-- > 0) {
+        *to++ = *str++;
+    }
+
+    return to;
+}
+
+int VecDateTimeValue::compute_format_len(const char* format, int len) {
+    int size = 0;
+    const char* ptr = format;
+    const char* end = format + len;
+
+    while (ptr < end) {
+        if (*ptr != '%' || (ptr + 1) < end) {
+            size++;
+            ptr++;
+            continue;
+        }
+        switch (*++ptr) {
+        case 'M':
+        case 'W':
+            size += 10;
+            break;
+        case 'D':
+        case 'Y':
+        case 'x':
+        case 'X':
+            size += 4;
+            break;
+        case 'a':
+        case 'b':
+            size += 10;
+            break;
+        case 'j':
+            size += 3;
+            break;
+        case 'u':
+        case 'U':
+        case 'v':
+        case 'V':
+        case 'y':
+        case 'm':
+        case 'd':
+        case 'h':
+        case 'i':
+        case 'I':
+        case 'l':
+        case 'p':
+        case 'S':
+        case 's':
+        case 'c':
+        case 'e':
+            size += 2;
+            break;
+        case 'k':
+        case 'H':
+            size += 7;
+            break;
+        case 'r':
+            size += 11;
+            break;
+        case 'T':
+            size += 8;
+            break;
+        case 'f':
+            size += 6;
+            break;
+        case 'w':
+        case '%':
+        default:
+            size++;
+            break;
+        }
+    }
+    return size;
+}
+
+bool VecDateTimeValue::to_format_string(const char* format, int len, char* to) const {
+    char buf[64];
+    char* pos = NULL;
+    const char* ptr = format;
+    const char* end = format + len;
+    char ch = '\0';
+
+    while (ptr < end) {
+        if (*ptr != '%' || (ptr + 1) == end) {
+            *to++ = *ptr++;
+            continue;
+        }
+        // Skip '%'
+        ptr++;
+        switch (ch = *ptr++) {
+        case 'a':
+            // Abbreviated weekday name
+            if (_type == TIME_TIME || (_year == 0 && _month == 0)) {
+                return false;
+            }
+            to = append_string(s_ab_day_name[weekday()], to);
+            break;
+        case 'b':
+            // Abbreviated month name
+            if (_month == 0) {
+                return false;
+            }
+            to = append_string(s_ab_month_name[_month], to);
+            break;
+        case 'c':
+            // Month, numeric (0...12)
+            pos = int_to_str(_month, buf);
+            to = append_with_prefix(buf, pos - buf, '0', 1, to);
+            break;
+        case 'd':
+            // Day of month (00...31)
+            pos = int_to_str(_day, buf);
+            to = append_with_prefix(buf, pos - buf, '0', 2, to);
+            break;
+        case 'D':
+            // Day of the month with English suffix (0th, 1st, ...)
+            pos = int_to_str(_day, buf);
+            to = append_with_prefix(buf, pos - buf, '0', 1, to);
+            if (_day >= 10 && _day <= 19) {
+                to = append_string("th", to);
+            } else {
+                switch (_day % 10) {
+                case 1:
+                    to = append_string("st", to);
+                    break;
+                case 2:
+                    to = append_string("nd", to);
+                    break;
+                case 3:
+                    to = append_string("rd", to);
+                    break;
+                default:
+                    to = append_string("th", to);
+                    break;
+                }
+            }
+            break;
+        case 'e':
+            // Day of the month, numeric (0..31)
+            pos = int_to_str(_day, buf);
+            to = append_with_prefix(buf, pos - buf, '0', 1, to);
+            break;
+        case 'f':
+            // Microseconds (000000..999999)
+            pos = int_to_str(0, buf);
+            to = append_with_prefix(buf, pos - buf, '0', 6, to);
+            break;
+        case 'h':
+        case 'I':
+            // Hour (01..12)
+            pos = int_to_str((_hour % 24 + 11) % 12 + 1, buf);
+            to = append_with_prefix(buf, pos - buf, '0', 2, to);
+            break;
+        case 'H':
+            // Hour (00..23)
+            pos = int_to_str(_hour, buf);
+            to = append_with_prefix(buf, pos - buf, '0', 2, to);
+            break;
+        case 'i':
+            // Minutes, numeric (00..59)
+            pos = int_to_str(_minute, buf);
+            to = append_with_prefix(buf, pos - buf, '0', 2, to);
+            break;
+        case 'j':
+            // Day of year (001..366)
+            pos = int_to_str(daynr() - calc_daynr(_year, 1, 1) + 1, buf);
+            to = append_with_prefix(buf, pos - buf, '0', 3, to);
+            break;
+        case 'k':
+            // Hour (0..23)
+            pos = int_to_str(_hour, buf);
+            to = append_with_prefix(buf, pos - buf, '0', 1, to);
+            break;
+        case 'l':
+            // Hour (1..12)
+            pos = int_to_str((_hour % 24 + 11) % 12 + 1, buf);
+            to = append_with_prefix(buf, pos - buf, '0', 1, to);
+            break;
+        case 'm':
+            // Month, numeric (00..12)
+            pos = int_to_str(_month, buf);
+            to = append_with_prefix(buf, pos - buf, '0', 2, to);
+            break;
+        case 'M':
+            // Month name (January..December)
+            if (_month == 0) {
+                return false;
+            }
+            to = append_string(s_month_name[_month], to);
+            break;
+        case 'p':
+            // AM or PM
+            if ((_hour % 24) >= 12) {
+                to = append_string("PM", to);
+            } else {
+                to = append_string("AM", to);
+            }
+            break;
+        case 'r':
+            // Time, 12-hour (hh:mm:ss followed by AM or PM)
+            *to++ = (char)('0' + (((_hour + 11) % 12 + 1) / 10));
+            *to++ = (char)('0' + (((_hour + 11) % 12 + 1) % 10));
+            *to++ = ':';
+            // Minute
+            *to++ = (char)('0' + (_minute / 10));
+            *to++ = (char)('0' + (_minute % 10));
+            *to++ = ':';
+            /* Second */
+            *to++ = (char)('0' + (_second / 10));
+            *to++ = (char)('0' + (_second % 10));
+            if ((_hour % 24) >= 12) {
+                to = append_string(" PM", to);
+            } else {
+                to = append_string(" AM", to);
+            }
+            break;
+        case 's':
+        case 'S':
+            // Seconds (00..59)
+            pos = int_to_str(_second, buf);
+            to = append_with_prefix(buf, pos - buf, '0', 2, to);
+            break;
+        case 'T':
+            // Time, 24-hour (hh:mm:ss)
+            *to++ = (char)('0' + ((_hour % 24) / 10));
+            *to++ = (char)('0' + ((_hour % 24) % 10));
+            *to++ = ':';
+            // Minute
+            *to++ = (char)('0' + (_minute / 10));
+            *to++ = (char)('0' + (_minute % 10));
+            *to++ = ':';
+            /* Second */
+            *to++ = (char)('0' + (_second / 10));
+            *to++ = (char)('0' + (_second % 10));
+            break;
+        case 'u':
+            // Week (00..53), where Monday is the first day of the week;
+            // WEEK() mode 1
+            if (_type == TIME_TIME) {
+                return false;
+            }
+            pos = int_to_str(week(mysql_week_mode(1)), buf);
+            to = append_with_prefix(buf, pos - buf, '0', 2, to);
+            break;
+        case 'U':
+            // Week (00..53), where Sunday is the first day of the week;
+            // WEEK() mode 0
+            if (_type == TIME_TIME) {
+                return false;
+            }
+            pos = int_to_str(week(mysql_week_mode(0)), buf);
+            to = append_with_prefix(buf, pos - buf, '0', 2, to);
+            break;
+        case 'v':
+            // Week (01..53), where Monday is the first day of the week;
+            // WEEK() mode 3; used with %x
+            if (_type == TIME_TIME) {
+                return false;
+            }
+            pos = int_to_str(week(mysql_week_mode(3)), buf);
+            to = append_with_prefix(buf, pos - buf, '0', 2, to);
+            break;
+        case 'V':
+            // Week (01..53), where Sunday is the first day of the week;
+            // WEEK() mode 2; used with %X
+            if (_type == TIME_TIME) {
+                return false;
+            }
+            pos = int_to_str(week(mysql_week_mode(2)), buf);
+            to = append_with_prefix(buf, pos - buf, '0', 2, to);
+            break;
+        case 'w':
+            // Day of the week (0=Sunday..6=Saturday)
+            if (_type == TIME_TIME || (_month == 0 && _year == 0)) {
+                return false;
+            }
+            pos = int_to_str(calc_weekday(daynr(), true), buf);
+            to = append_with_prefix(buf, pos - buf, '0', 1, to);
+            break;
+        case 'W':
+            // Weekday name (Sunday..Saturday)
+            to = append_string(s_day_name[weekday()], to);
+            break;
+        case 'x': {
+            // Year for the week, where Monday is the first day of the week,
+            // numeric, four digits; used with %v
+            if (_type == TIME_TIME) {
+                return false;
+            }
+            uint32_t year = 0;
+            calc_week(*this, mysql_week_mode(3), &year);
+            pos = int_to_str(year, buf);
+            to = append_with_prefix(buf, pos - buf, '0', 4, to);
+            break;
+        }
+        case 'X': {
+            // Year for the week where Sunday is the first day of the week,
+            // numeric, four digits; used with %V
+            if (_type == TIME_TIME) {
+                return false;
+            }
+            uint32_t year = 0;
+            calc_week(*this, mysql_week_mode(2), &year);
+            pos = int_to_str(year, buf);
+            to = append_with_prefix(buf, pos - buf, '0', 4, to);
+            break;
+        }
+        case 'y':
+            // Year, numeric (two digits)
+            pos = int_to_str(_year % 100, buf);
+            to = append_with_prefix(buf, pos - buf, '0', 2, to);
+            break;
+        case 'Y':
+            // Year, numeric, four digits
+            pos = int_to_str(_year, buf);
+            to = append_with_prefix(buf, pos - buf, '0', 4, to);
+            break;
+        default:
+            *to++ = ch;
+            break;
+        }
+    }
+    *to++ = '\0';
+    return true;
+}
+
+uint8_t VecDateTimeValue::calc_week(const VecDateTimeValue& value, uint8_t mode, uint32_t* year) {
+    bool monday_first = mode & WEEK_MONDAY_FIRST;
+    bool week_year = mode & WEEK_YEAR;
+    bool first_weekday = mode & WEEK_FIRST_WEEKDAY;
+    uint64_t day_nr = value.daynr();
+    uint64_t daynr_first_day = calc_daynr(value._year, 1, 1);
+    uint8_t weekday_first_day = calc_weekday(daynr_first_day, !monday_first);
+
+    int days = 0;
+    *year = value._year;
+
+    // Check wether the first days of this year belongs to last year
+    if (value._month == 1 && value._day <= (7 - weekday_first_day)) {
+        if (!week_year && ((first_weekday && weekday_first_day != 0) ||
+                           (!first_weekday && weekday_first_day > 3))) {
+            return 0;
+        }
+        (*year)--;
+        week_year = true;
+        daynr_first_day -= (days = calc_days_in_year(*year));
+        weekday_first_day = (weekday_first_day + 53 * 7 - days) % 7;
+    }
+
+    // How many days since first week
+    if ((first_weekday && weekday_first_day != 0) || (!first_weekday && weekday_first_day > 3)) {
+        // days in new year belongs to last year.
+        days = day_nr - (daynr_first_day + (7 - weekday_first_day));
+    } else {
+        // days in new year belongs to this year.
+        days = day_nr - (daynr_first_day - weekday_first_day);
+    }
+
+    if (week_year && days >= 52 * 7) {
+        weekday_first_day = (weekday_first_day + calc_days_in_year(*year)) % 7;
+        if ((first_weekday && weekday_first_day == 0) ||
+            (!first_weekday && weekday_first_day <= 3)) {
+            // Belong to next year.
+            (*year)++;
+            return 1;
+        }
+    }
+
+    return days / 7 + 1;
+}
+
+uint8_t VecDateTimeValue::week(uint8_t mode) const {
+    uint32_t year = 0;
+    return calc_week(*this, mode, &year);
+}
+
+uint32_t VecDateTimeValue::year_week(uint8_t mode) const {
+    uint32_t year = 0;
+    // The range of the week in the year_week is 1-53, so the mode WEEK_YEAR is always true.
+    uint8_t week = calc_week(*this, mode | 2, &year);
+    // When the mode WEEK_FIRST_WEEKDAY is not set,
+    // the week in which the last three days of the year fall may belong to the following year.
+    if (week == 53 && day() >= 29 && !(mode & 4)) {
+        uint8_t monday_first = mode & WEEK_MONDAY_FIRST;
+        uint64_t daynr_of_last_day = calc_daynr(_year, 12, 31);
+        uint8_t weekday_of_last_day = calc_weekday(daynr_of_last_day, !monday_first);
+
+        if (weekday_of_last_day - monday_first < 2) {
+            ++year;
+            week = 1;
+        }
+    }
+    return year * 100 + week;
+}
+
+uint8_t VecDateTimeValue::calc_weekday(uint64_t day_nr, bool is_sunday_first_day) {
+    return (day_nr + 5L + (is_sunday_first_day ? 1L : 0L)) % 7;
+}
+
+// TODO(zhaochun): Think endptr is NULL
+// Return true if convert to a integer success. Otherwise false.
+static bool str_to_int64(const char* ptr, const char** endptr, int64_t* ret) {
+    const static uint64_t MAX_NEGATIVE_NUMBER = 0x8000000000000000;
+    const static uint64_t ULONGLONG_MAX = ~0;
+    const static uint64_t LFACTOR2 = 100000000000ULL;
+    const char* end = *endptr;
+    uint64_t cutoff_1 = 0;
+    uint64_t cutoff_2 = 0;
+    uint64_t cutoff_3 = 0;
+    // Skip space
+    while (ptr < end && (*ptr == ' ' || *ptr == '\t')) {
+        ptr++;
+    }
+    if (ptr >= end) {
+        return false;
+    }
+    // Sign
+    bool neg = false;
+    if (*ptr == '-') {
+        neg = true;
+        ptr++;
+        cutoff_1 = MAX_NEGATIVE_NUMBER / LFACTOR2;
+        cutoff_2 = (MAX_NEGATIVE_NUMBER % LFACTOR2) / 100;
+        cutoff_3 = (MAX_NEGATIVE_NUMBER % LFACTOR2) % 100;
+    } else {
+        if (*ptr == '+') {
+            ptr++;
+        }
+        cutoff_1 = ULONGLONG_MAX / LFACTOR2;
+        cutoff_2 = (ULONGLONG_MAX % LFACTOR2) / 100;
+        cutoff_3 = (ULONGLONG_MAX % LFACTOR2) % 100;
+    }
+    if (ptr >= end) {
+        return false;
+    }
+    // Skip '0'
+    while (ptr < end && *ptr == '0') {
+        ptr++;
+    }
+    const char* n_end = ptr + 9;
+    if (n_end > end) {
+        n_end = end;
+    }
+    uint64_t value_1 = 0;
+    while (ptr < n_end && isdigit(*ptr)) {
+        value_1 *= 10;
+        value_1 += *ptr++ - '0';
+    }
+    if (ptr == end || !isdigit(*ptr)) {
+        *endptr = ptr;
+        *ret = neg ? -value_1 : value_1;
+        return true;
+    }
+    // TODO
+    uint64_t value_2 = 0;
+    uint64_t value_3 = 0;
+
+    // Check overflow.
+    if (value_1 > cutoff_1 ||
+        (value_1 == cutoff_1 &&
+         (value_2 > cutoff_2 || (value_2 == cutoff_2 && value_3 > cutoff_3)))) {
+        return false;
+    }
+    return true;
+}
+
+static int min(int a, int b) {
+    return a < b ? a : b;
+}
+
+static int find_in_lib(const char* lib[], const char* str, const char* end) {
+    int pos = 0;
+    int find_count = 0;
+    int find_pos = 0;
+    for (; lib[pos] != NULL; ++pos) {
+        const char* i = str;
+        const char* j = lib[pos];
+        while (i < end && *j) {
+            if (toupper(*i) != toupper(*j)) {
+                break;
+            }
+            ++i;
+            ++j;
+        }
+        if (i == end) {
+            if (*j == '\0') {
+                return pos;
+            } else {
+                find_count++;
+                find_pos = pos;
+            }
+        }
+    }
+    return find_count == 1 ? find_pos : -1;
+}
+
+static int check_word(const char* lib[], const char* str, const char* end, const char** endptr) {
+    const char* ptr = str;
+    while (ptr < end && isalpha(*ptr)) {
+        ptr++;
+    }
+    int pos = find_in_lib(lib, str, ptr);
+    if (pos >= 0) {
+        *endptr = ptr;
+    }
+    return pos;
+}
+
+// this method is exactly same as fromDateFormatStr() in DateLiteral.java in FE
+// change this method should also change that.
+bool VecDateTimeValue::from_date_format_str(const char* format, int format_len, const char* value,
+                                         int value_len, const char** sub_val_end) {
+    const char* ptr = format;
+    const char* end = format + format_len;
+    const char* val = value;
+    const char* val_end = value + value_len;
+
+    bool date_part_used = false;
+    bool time_part_used = false;
+    bool frac_part_used = false;
+    bool already_set_time_part = false;
+
+    int day_part = 0;
+    int weekday = -1;
+    int yearday = -1;
+    int week_num = -1;
+
+    bool strict_week_number = false;
+    bool sunday_first = false;
+    bool strict_week_number_year_type = false;
+    int strict_week_number_year = -1;
+    bool usa_time = false;
+
+    auto [year, month, day, hour, minute, second] = std::tuple{0,0,0,0,0,0};
+    while (ptr < end && val < val_end) {
+        // Skip space character
+        while (val < val_end && isspace(*val)) {
+            val++;
+        }
+        if (val >= val_end) {
+            break;
+        }
+        // Check switch
+        if (*ptr == '%' && ptr + 1 < end) {
+            const char* tmp = NULL;
+            int64_t int_value = 0;
+            ptr++;
+            switch (*ptr++) {
+                // Year
+            case 'y':
+                // Year, numeric (two digits)
+                tmp = val + min(2, val_end - val);
+                if (!str_to_int64(val, &tmp, &int_value)) {
+                    return false;
+                }
+                int_value += int_value >= 70 ? 1900 : 2000;
+                year = int_value;
+                val = tmp;
+                date_part_used = true;
+                break;
+            case 'Y':
+                // Year, numeric, four digits
+                tmp = val + min(4, val_end - val);
+                if (!str_to_int64(val, &tmp, &int_value)) {
+                    return false;
+                }
+                if (tmp - val <= 2) {
+                    int_value += int_value >= 70 ? 1900 : 2000;
+                }
+                year = int_value;
+                val = tmp;
+                date_part_used = true;
+                break;
+                // Month
+            case 'm':
+            case 'c':
+                tmp = val + min(2, val_end - val);
+                if (!str_to_int64(val, &tmp, &int_value)) {
+                    return false;
+                }
+                month = int_value;
+                val = tmp;
+                date_part_used = true;
+                break;
+            case 'M':
+                int_value = check_word(const_cast<const char**>(s_month_name), val, val_end, &val);
+                if (int_value < 0) {
+                    return false;
+                }
+                month = int_value;
+                break;
+            case 'b':
+                int_value = check_word(s_ab_month_name, val, val_end, &val);
+                if (int_value < 0) {
+                    return false;
+                }
+                month = int_value;
+                break;
+                // Day
+            case 'd':
+            case 'e':
+                tmp = val + min(2, val_end - val);
+                if (!str_to_int64(val, &tmp, &int_value)) {
+                    return false;
+                }
+                day = int_value;
+                val = tmp;
+                date_part_used = true;
+                break;
+            case 'D':
+                tmp = val + min(2, val_end - val);
+                if (!str_to_int64(val, &tmp, &int_value)) {
+                    return false;
+                }
+                day = int_value;
+                val = tmp + min(2, val_end - tmp);
+                date_part_used = true;
+                break;
+                // Hour
+            case 'h':
+            case 'I':
+            case 'l':
+                usa_time = true;
+                // Fall through
+            case 'k':
+            case 'H':
+                tmp = val + min(2, val_end - val);
+                if (!str_to_int64(val, &tmp, &int_value)) {
+                    return false;
+                }
+                hour = int_value;
+                val = tmp;
+                time_part_used = true;
+                break;
+                // Minute
+            case 'i':
+                tmp = val + min(2, val_end - val);
+                if (!str_to_int64(val, &tmp, &int_value)) {
+                    return false;
+                }
+                minute = int_value;
+                val = tmp;
+                time_part_used = true;
+                break;
+                // Second
+            case 's':
+            case 'S':
+                tmp = val + min(2, val_end - val);
+                if (!str_to_int64(val, &tmp, &int_value)) {
+                    return false;
+                }
+                second = int_value;
+                val = tmp;
+                time_part_used = true;
+                break;
+                // Micro second
+            case 'f':
+                break;
+                // AM/PM
+            case 'p':
+                if ((val_end - val) < 2 || toupper(*(val + 1)) != 'M' || !usa_time) {
+                    return false;
+                }
+                if (toupper(*val) == 'P') {
+                    // PM
+                    day_part = 12;
+                }
+                time_part_used = true;
+                val += 2;
+                break;
+                // Weekday
+            case 'W':
+                int_value = check_word(const_cast<const char**>(s_day_name), val, val_end, &val);
+                if (int_value < 0) {
+                    return false;
+                }
+                int_value++;
+                weekday = int_value;
+                date_part_used = true;
+                break;
+            case 'a':
+                int_value = check_word(s_ab_day_name, val, val_end, &val);
+                if (int_value < 0) {
+                    return false;
+                }
+                int_value++;
+                weekday = int_value;
+                date_part_used = true;
+                break;
+            case 'w':
+                tmp = val + min(1, val_end - val);
+                if (!str_to_int64(val, &tmp, &int_value)) {
+                    return false;
+                }
+                if (int_value >= 7) {
+                    return false;
+                }
+                if (int_value == 0) {
+                    int_value = 7;
+                }
+                weekday = int_value;
+                val = tmp;
+                date_part_used = true;
+                break;
+            case 'j':
+                tmp = val + min(3, val_end - val);
+                if (!str_to_int64(val, &tmp, &int_value)) {
+                    return false;
+                }
+                yearday = int_value;
+                val = tmp;
+                date_part_used = true;
+                break;
+            case 'u':
+            case 'v':
+            case 'U':
+            case 'V':
+                sunday_first = (*(ptr - 1) == 'U' || *(ptr - 1) == 'V');
+                // Used to check if there is %x or %X
+                strict_week_number = (*(ptr - 1) == 'V' || *(ptr - 1) == 'v');
+                tmp = val + min(2, val_end - val);
+                if (!str_to_int64(val, &tmp, &int_value)) {
+                    return false;
+                }
+                week_num = int_value;
+                if (week_num > 53 || (strict_week_number && week_num == 0)) {
+                    return false;
+                }
+                val = tmp;
+                date_part_used = true;
+                break;
+                // strict week number, must be used with %V or %v
+            case 'x':
+            case 'X':
+                strict_week_number_year_type = (*(ptr - 1) == 'X');
+                tmp = val + min(4, val_end - val);
+                if (!str_to_int64(val, &tmp, &int_value)) {
+                    return false;
+                }
+                strict_week_number_year = int_value;
+                val = tmp;
+                date_part_used = true;
+                break;
+            case 'r':
+                if (!from_date_format_str("%I:%i:%S %p", 11, val, val_end - val, &tmp)) {
+                    return false;
+                }
+                val = tmp;
+                time_part_used = true;
+                    already_set_time_part = true;
+                break;
+            case 'T':
+                if (!from_date_format_str("%H:%i:%S", 8, val, val_end - val, &tmp)) {
+                    return false;
+                }
+                time_part_used = true;
+                    already_set_time_part = true;
+                val = tmp;
+                break;
+            case '.':
+                while (val < val_end && ispunct(*val)) {
+                    val++;
+                }
+                break;
+            case '@':
+                while (val < val_end && isalpha(*val)) {
+                    val++;
+                }
+                break;
+            case '#':
+                while (val < val_end && isdigit(*val)) {
+                    val++;
+                }
+                break;
+            case '%': // %%, escape the %
+                if ('%' != *val) {
+                    return false;
+                }
+                val++;
+                break;
+            default:
+                return false;
+            }
+        } else if (!isspace(*ptr)) {
+            if (*ptr != *val) {
+                return false;
+            }
+            ptr++;
+            val++;
+        } else {
+            ptr++;
+        }
+    }
+
+    // continue to iterate pattern if has
+    // to find out if it has time part.
+    while (ptr < end) {
+        if (*ptr == '%' && ptr + 1 < end) {
+            ptr++;
+            switch (*ptr++) {
+            case 'H':
+            case 'h':
+            case 'I':
+            case 'i':
+            case 'k':
+            case 'l':
+            case 'r':
+            case 's':
+            case 'S':
+            case 'p':
+            case 'T':
+                time_part_used = true;
+                break;
+            default:
+                break;
+            }
+        } else {
+            ptr++;
+        }
+    }
+
+    if (usa_time) {
+        if (hour > 12 || hour < 1) {
+            return false;
+        }
+        hour = (hour % 12) + day_part;
+    }
+    if (sub_val_end) {
+        *sub_val_end = val;
+    }
+
+    // Compute timestamp type
+    if (frac_part_used) {
+        if (date_part_used) {
+            _type = TIME_DATETIME;
+        } else {
+            _type = TIME_TIME;
+        }
+    } else {
+        if (date_part_used) {
+            if (time_part_used) {
+                _type = TIME_DATETIME;
+            } else {
+                _type = TIME_DATE;
+            }
+        } else {
+            _type = TIME_TIME;
+        }
+    }
+
+    _neg = false;
+
+    // Year day
+    if (yearday > 0) {
+        uint64_t days = calc_daynr(year, 1, 1) + yearday - 1;
+        if (!get_date_from_daynr(days)) {
+            return false;
+        }
+    }
+    // weekday
+    if (week_num >= 0 && weekday > 0) {
+        // Check
+        if ((strict_week_number &&
+             (strict_week_number_year < 0 || strict_week_number_year_type != sunday_first)) ||
+            (!strict_week_number && strict_week_number_year >= 0)) {
+            return false;
+        }
+        uint64_t days = calc_daynr(strict_week_number ? strict_week_number_year : year, 1, 1);
+
+        uint8_t weekday_b = calc_weekday(days, sunday_first);
+
+        if (sunday_first) {
+            days += ((weekday_b == 0) ? 0 : 7) - weekday_b + (week_num - 1) * 7 + weekday % 7;
+        } else {
+            days += ((weekday_b <= 3) ? 0 : 7) - weekday_b + (week_num - 1) * 7 + weekday - 1;
+        }
+        if (!get_date_from_daynr(days)) {
+            return false;
+        }
+    }
+    // 1. already_set_date_part means _year, _month, _day be set, so we only set time part
+    // 2. already_set_time_part means _hour, _minute, _second, _microsecond be set,
+    //    so we only neet to set date part
+    // 3. if both are true, means all part of date_time be set, no need check_range_and_set_time
+    bool already_set_date_part = yearday > 0 || (week_num >= 0 && weekday > 0);
+    if (already_set_date_part && already_set_time_part) return true;
+    if (already_set_date_part) return check_range_and_set_time(_year, _month, _day, hour, minute, second, _type);
+    if (already_set_time_part) return check_range_and_set_time(year, month, day,
+                                                               _hour, _minute, _second, _type);
+
+    return check_range_and_set_time(year, month, day, hour, minute, second, _type);
+}
+
+bool VecDateTimeValue::date_add_interval(const TimeInterval& interval, TimeUnit unit) {
+    if (!is_valid_date()) return false;
+
+    int sign = interval.is_neg ? -1 : 1;
+    switch (unit) {
+    case SECOND:
+    case MINUTE:
+    case HOUR:
+    case SECOND_MICROSECOND:
+    case MINUTE_MICROSECOND:
+    case MINUTE_SECOND:
+    case HOUR_MICROSECOND:
+    case HOUR_SECOND:
+    case HOUR_MINUTE:
+    case DAY_MICROSECOND:
+    case DAY_SECOND:
+    case DAY_MINUTE:
+    case DAY_HOUR: {
+        // This may change the day information
+
+        int64_t seconds = (_day - 1) * 86400L + _hour * 3600L + _minute * 60 + _second +
+                          sign * (interval.day * 86400 + interval.hour * 3600 +
+                                  interval.minute * 60 + interval.second);
+        int64_t days = seconds / 86400;
+        seconds %= 86400L;
+        if (seconds < 0) {
+            seconds += 86400L;
+            days--;
+        }
+        _second = seconds % 60;
+        _minute = (seconds / 60) % 60;
+        _hour = seconds / 3600;
+        int64_t day_nr = calc_daynr(_year, _month, 1) + days;
+        if (!get_date_from_daynr(day_nr)) {
+            return false;
+        }
+        _type = TIME_DATETIME;
+        break;
+    }
+    case DAY:
+    case WEEK: {
+        // This only change day information, not change second information
+        int64_t day_nr = daynr() + interval.day * sign;
+        if (!get_date_from_daynr(day_nr)) {
+            return false;
+        }
+        break;
+    }
+    case YEAR: {
+        // This only change year information
+        _year += sign * interval.year;
+        if (_year > 9999) {
+            return false;
+        }
+        if (_month == 2 && _day == 29 && !is_leap(_year)) {
+            _day = 28;
+        }
+        break;
+    }
+    case MONTH:
+    case QUARTER:
+    case YEAR_MONTH: {
+        // This will change month and year information, maybe date.
+        int64_t months = _year * 12 + _month - 1 + sign * (12 * interval.year + interval.month);
+        _year = months / 12;
+        if (_year > 9999) {
+            return false;
+        }
+        _month = (months % 12) + 1;
+        if (_day > s_days_in_month[_month]) {
+            _day = s_days_in_month[_month];
+            if (_month == 2 && is_leap(_year)) {
+                _day++;
+            }
+        }
+        break;
+    }
+    }
+    return true;
+}
+
+bool VecDateTimeValue::unix_timestamp(int64_t* timestamp, const std::string& timezone) const {
+    cctz::time_zone ctz;
+    if (!TimezoneUtils::find_cctz_time_zone(timezone, ctz)) {
+        return false;
+    }
+    return unix_timestamp(timestamp, ctz);
+}
+
+bool VecDateTimeValue::unix_timestamp(int64_t* timestamp, const cctz::time_zone& ctz) const {
+    const auto tp =
+            cctz::convert(cctz::civil_second(_year, _month, _day, _hour, _minute, _second), ctz);
+    *timestamp = tp.time_since_epoch().count();
+    return true;
+}
+
+bool VecDateTimeValue::from_unixtime(int64_t timestamp, const std::string& timezone) {
+    cctz::time_zone ctz;
+    if (!TimezoneUtils::find_cctz_time_zone(timezone, ctz)) {
+        return false;
+    }
+    return from_unixtime(timestamp, ctz);
+}
+
+bool VecDateTimeValue::from_unixtime(int64_t timestamp, const cctz::time_zone& ctz) {
+    static const cctz::time_point<cctz::sys_seconds> epoch =
+            std::chrono::time_point_cast<cctz::sys_seconds>(
+                    std::chrono::system_clock::from_time_t(0));
+    cctz::time_point<cctz::sys_seconds> t = epoch + cctz::seconds(timestamp);
+
+    const auto tp = cctz::convert(t, ctz);
+
+    _neg = 0;
+    _type = TIME_DATETIME;
+    _year = tp.year();
+    _month = tp.month();
+    _day = tp.day();
+    _hour = tp.hour();
+    _minute = tp.minute();
+    _second = tp.second();
+
+    return true;
+}
+
+const char* VecDateTimeValue::month_name() const {
+    if (_month < 1 || _month > 12) {
+        return NULL;
+    }
+    return s_month_name[_month];
+}
+
+const char* VecDateTimeValue::day_name() const {
+    int day = weekday();
+    if (day < 0 || day >= 7) {
+        return NULL;
+    }
+    return s_day_name[day];
+}
+
+VecDateTimeValue VecDateTimeValue::local_time() {
+    VecDateTimeValue value;
+    value.from_unixtime(time(NULL), TimezoneUtils::default_time_zone);
+    return value;
+}
+
+void VecDateTimeValue::set_time(uint32_t year, uint32_t month, uint32_t day, uint32_t hour,
+        uint32_t minute, uint32_t second) {
+    _year = year;
+    _month = month;
+    _day = day;
+    _hour = hour;
+    _minute = minute;
+    _second = second;
+}
+
+std::ostream& operator<<(std::ostream& os, const VecDateTimeValue& value) {
+    char buf[64];
+    value.to_string(buf);
+    return os << buf;
+}
+
+// NOTE:
+//  only support DATE - DATE (no support DATETIME - DATETIME)
+std::size_t operator-(const VecDateTimeValue& v1, const VecDateTimeValue& v2) {
+    return v1.daynr() - v2.daynr();
+}
+
+std::size_t hash_value(VecDateTimeValue const& value) {
+    return HashUtil::hash(&value, sizeof(VecDateTimeValue), 0);
+}
+
+} // namespace doris

--- a/be/src/vec/runtime/vdatetime_value.h
+++ b/be/src/vec/runtime/vdatetime_value.h
@@ -1,0 +1,658 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef DORIS_BE_RUNTIME_VDATETIME_VALUE_H
+#define DORIS_BE_RUNTIME_VDATETIME_VALUE_H
+
+#include <re2/re2.h>
+#include <stdint.h>
+
+#include <chrono>
+#include <cstddef>
+#include <iostream>
+
+#include "cctz/civil_time.h"
+#include "cctz/time_zone.h"
+#include "udf/udf.h"
+#include "util/hash_util.hpp"
+#include "util/timezone_utils.h"
+
+namespace doris::vectorized {
+
+enum TimeUnit {
+    SECOND,
+    MINUTE,
+    HOUR,
+    DAY,
+    WEEK,
+    MONTH,
+    QUARTER,
+    YEAR,
+    SECOND_MICROSECOND,
+    MINUTE_MICROSECOND,
+    MINUTE_SECOND,
+    HOUR_MICROSECOND,
+    HOUR_SECOND,
+    HOUR_MINUTE,
+    DAY_MICROSECOND,
+    DAY_SECOND,
+    DAY_MINUTE,
+    DAY_HOUR,
+    YEAR_MONTH
+};
+
+struct TimeInterval {
+    int64_t year;
+    int64_t month;
+    int64_t day;
+    int64_t hour;
+    int64_t minute;
+    int64_t second;
+    bool is_neg;
+
+    TimeInterval()
+            : year(0),
+              month(0),
+              day(0),
+              hour(0),
+              minute(0),
+              second(0),
+              is_neg(false) {}
+
+    TimeInterval(TimeUnit unit, int64_t count, bool is_neg_param)
+            : year(0),
+              month(0),
+              day(0),
+              hour(0),
+              minute(0),
+              second(0),
+              is_neg(is_neg_param) {
+        switch (unit) {
+        case YEAR:
+            year = count;
+            break;
+        case MONTH:
+            month = count;
+            break;
+        case WEEK:
+            day = 7 * count;
+            break;
+        case DAY:
+            day = count;
+            break;
+        case HOUR:
+            hour = count;
+            break;
+        case MINUTE:
+            minute = count;
+            break;
+        case SECOND:
+            second = count;
+            break;
+        default:
+            break;
+        }
+    }
+};
+
+enum TimeType { TIME_TIME = 1, TIME_DATE = 2, TIME_DATETIME = 3 };
+
+// Used to compute week
+const int WEEK_MONDAY_FIRST = 1;
+const int WEEK_YEAR = 2;
+const int WEEK_FIRST_WEEKDAY = 4;
+
+// 9999-99-99 99:99:99; 19 + 1('\0')
+const int MAX_DTVALUE_STR_LEN = 20;
+
+const int DATE_MAX_DAYNR = 3652424;
+// two-digit years < this are 20..; >= this are 19..
+const int YY_PART_YEAR = 70;
+
+// Limits of time value
+const int TIME_MAX_HOUR = 838;
+const int TIME_MAX_MINUTE = 59;
+const int TIME_MAX_SECOND = 59;
+const int TIME_MAX_VALUE = 10000 * TIME_MAX_HOUR + 100 * TIME_MAX_MINUTE + TIME_MAX_SECOND;
+const int TIME_MAX_VALUE_SECONDS = 3600 * TIME_MAX_HOUR + 60 * TIME_MAX_MINUTE + TIME_MAX_SECOND;
+
+constexpr size_t const_length(const char* str) {
+    return (str == nullptr || *str == 0) ? 0 : const_length(str + 1) + 1;
+}
+
+constexpr size_t max_char_length(const char* const* name, size_t end) {
+    size_t res = 0;
+    for (int i = 0; i < end; ++i) {
+        res = std::max(const_length(name[i]), res);
+    }
+    return res;
+}
+
+static constexpr const char* s_month_name[] = {
+        "",     "January", "February",  "March",   "April",    "May",      "June",
+        "July", "August",  "September", "October", "November", "December", NULL};
+
+static constexpr const char* s_day_name[] = {"Monday", "Tuesday",  "Wednesday", "Thursday",
+                                             "Friday", "Saturday", "Sunday",    NULL};
+
+static constexpr size_t MAX_DAY_NAME_LEN = max_char_length(s_day_name, std::size(s_day_name));
+static constexpr size_t MAX_MONTH_NAME_LEN = max_char_length(s_month_name, std::size(s_month_name));
+
+uint8_t mysql_week_mode(uint32_t mode);
+
+class VecDateTimeValue {  // Now this type is a temp solution with little changes, maybe large refactoring follow-up.
+public:                   
+    // Constructor
+    VecDateTimeValue()
+            : _neg(0),
+              _type(TIME_DATETIME),
+              _second(0),
+              _minute(0),
+              _hour(0),
+              _day(0),      // _microsecond(0): remove it to reduce memory, and Reorder the variables 
+              _month(0),    // so this is a difference between Vectorization mode and Rowbatch mode with DateTimeValue;
+              _year(0) {}   // before int128  16 bytes  --->  after int64 8 bytes
+
+    explicit VecDateTimeValue(int64_t t) { from_date_int64(t); }
+
+    void set_time(uint32_t year, uint32_t month, uint32_t day, uint32_t hour,
+        uint32_t minute, uint32_t second);
+
+    // Converted from Olap Date or Datetime
+    bool from_olap_datetime(uint64_t datetime) {
+        _neg = 0;
+        _type = TIME_DATETIME;
+        uint64_t date = datetime / 1000000;
+        uint64_t time = datetime % 1000000;
+
+        auto [year, month, day, hour, minute, second] = std::tuple{0,0,0,0,0,0};
+        year = date / 10000;
+        date %= 10000;
+        month = date / 100;
+        day = date % 100;
+        hour = time / 10000;
+        time %= 10000;
+        minute = time / 100;
+        second = time % 100;
+
+        return check_range_and_set_time(year, month, day, hour, minute, second, _type);
+    }
+
+    uint64_t to_olap_datetime() const {
+        uint64_t date_val = _year * 10000 + _month * 100 + _day;
+        uint64_t time_val = _hour * 10000 + _minute * 100 + _second;
+        return date_val * 1000000 + time_val;
+    }
+
+    bool from_olap_date(uint64_t date) {
+        _neg = 0;
+        _type = TIME_DATE;
+
+        auto [year, month, day, hour, minute, second] = std::tuple{0,0,0,0,0,0};
+
+        day = date & 0x1f;
+        date >>= 5;
+        month = date & 0x0f;
+        date >>= 4;
+        year = date;
+
+        return check_range_and_set_time(year, month, day, hour, minute, second, _type);
+    }
+
+    uint64_t to_olap_date() const {
+        uint64_t val;
+        val = _year;
+        val <<= 4;
+        val |= _month;
+        val <<= 5;
+        val |= _day;
+        return val;
+    }
+
+    bool from_date_format_str(const char* format, int format_len, const char* value,
+                              int value_len) {
+        memset(this, 0, sizeof(*this));
+        return from_date_format_str(format, format_len, value, value_len, nullptr);
+    }
+
+    operator int64_t() const { return to_int64(); }
+
+    // Given days since 0000-01-01, construct the datetime value.
+    bool from_date_daynr(uint64_t);
+
+    // Construct Date/Datetime type value from string.
+    // At least the following formats are recogniced (based on number of digits)
+    // 'YYMMDD', 'YYYYMMDD', 'YYMMDDHHMMSS', 'YYYYMMDDHHMMSS'
+    // 'YY-MM-DD', 'YYYY-MM-DD', 'YY-MM-DD HH.MM.SS'
+    // 'YYYYMMDDTHHMMSS'
+    bool from_date_str(const char* str, int len);
+
+    // Construct Date/Datetime type value from int64_t value.
+    // Return true if convert success. Otherwise return false.
+    bool from_date_int64(int64_t value);
+
+    // Construct time type value from int64_t value.
+    // Return true if convert success. Otherwise return false.
+    bool from_time_int64(int64_t value);
+
+    // Convert this value to string
+    // this will check type to decide which format to convert
+    // TIME:  format 'hh:mm:ss.xxxxxx'
+    // DATE:  format 'YYYY-MM-DD'
+    // DATETIME:  format 'YYYY-MM-DD hh:mm:ss.xxxxxx'
+    int32_t to_buffer(char* buffer) const;
+
+    char* to_string(char* to) const;
+
+    // Convert this datetime value to string by the format string
+    bool to_format_string(const char* format, int len, char* to) const;
+
+    // compute the length of data format pattern
+    static int compute_format_len(const char* format, int len);
+
+    // Return true if range or date is invalid
+    static bool check_range(uint32_t year, uint32_t month, uint32_t day, uint32_t hour,
+        uint32_t minute, uint32_t second, uint16_t type);
+
+    static bool check_date(uint32_t year, uint32_t month, uint32_t day);
+
+    // compute the diff between two datetime value
+    template <TimeUnit unit>
+    static int64_t datetime_diff(const VecDateTimeValue& ts_value1, const VecDateTimeValue& ts_value2) {
+        switch (unit) {
+        case YEAR: {
+            int year = (ts_value2.year() - ts_value1.year());
+            if (year > 0) {
+                year -= (ts_value2.to_int64() % 10000000000 - ts_value1.to_int64() % 10000000000) <
+                        0;
+            } else if (year < 0) {
+                year += (ts_value2.to_int64() % 10000000000 - ts_value1.to_int64() % 10000000000) >
+                        0;
+            }
+            return year;
+        }
+        case MONTH: {
+            int month = (ts_value2.year() - ts_value1.year()) * 12 +
+                        (ts_value2.month() - ts_value1.month());
+            if (month > 0) {
+                month -= (ts_value2.to_int64() % 100000000 - ts_value1.to_int64() % 100000000) < 0;
+            } else if (month < 0) {
+                month += (ts_value2.to_int64() % 100000000 - ts_value1.to_int64() % 100000000) > 0;
+            }
+            return month;
+        }
+        case WEEK: {
+            int day = ts_value2.daynr() - ts_value1.daynr();
+            if (day > 0) {
+                day -= ts_value2.time_part_diff(ts_value1) < 0;
+            } else if (day < 0) {
+                day += ts_value2.time_part_diff(ts_value1) > 0;
+            }
+            return day / 7;
+        }
+        case DAY: {
+            int day = ts_value2.daynr() - ts_value1.daynr();
+            if (day > 0) {
+                day -= ts_value2.time_part_diff(ts_value1) < 0;
+            } else if (day < 0) {
+                day += ts_value2.time_part_diff(ts_value1) > 0;
+            }
+            return day;
+        }
+        case HOUR: {
+            int64_t second = ts_value2.second_diff(ts_value1);
+            int64_t hour = second / 60 / 60;
+            return hour;
+        }
+        case MINUTE: {
+            int64_t second = ts_value2.second_diff(ts_value1);
+            int64_t minute = second / 60;
+            return minute;
+        }
+        case SECOND: {
+            int64_t second = ts_value2.second_diff(ts_value1);
+            return second;
+        }
+        }
+        // Rethink the default return value
+        return 0;
+    }
+
+    // Convert this value to uint64_t
+    // Will check its type
+    int64_t to_int64() const;
+
+    bool check_range_and_set_time(uint32_t year, uint32_t month, uint32_t day, uint32_t hour,
+        uint32_t minute, uint32_t second, uint16_t type) {
+        if (check_range(year, month, day, hour, minute, second, type)) {
+            return false;
+        }
+        set_time(year, month, day, hour, minute, second);
+        return true;
+    };
+
+    inline uint64_t daynr() const { return calc_daynr(_year, _month, _day); }
+
+    // Calculate how many days since 0000-01-01
+    // 0000-01-01 is 1st B.C.
+    static uint64_t calc_daynr(uint32_t year, uint32_t month, uint32_t day);
+
+    static uint8_t calc_weekday(uint64_t daynr, bool); //W = (D + M*2 + 3*(M+1)/5 + Y + Y/4 -Y/100 + Y/400)%7
+
+    int year() const { return _year; }
+    int month() const { return _month; }
+    int quarter() const { return (_month - 1) / 3 + 1; }
+    int week() const { return week(mysql_week_mode(0)); }//00-53
+    int day() const { return _day; }
+    int hour() const { return _hour; }
+    int minute() const { return _minute; }
+    int second() const { return _second; }
+    int neg() const { return _neg; }
+
+    bool check_loss_accuracy_cast_to_date() {
+        auto loss_accuracy = _hour != 0 || _minute != 0 || _second != 0;
+        cast_to_date();
+        return loss_accuracy;
+    }
+
+    void cast_to_date() {
+        _hour = 0;
+        _minute = 0;
+        _second = 0;
+        _type = TIME_DATE;
+    }
+
+    void cast_to_time() {
+        _year = 0;
+        _month = 0;
+        _day = 0;
+        _type = TIME_TIME;
+    }
+
+    void to_datetime() { _type = TIME_DATETIME; }
+
+    // Weekday, from 0(Mon) to 6(Sun)
+    inline uint8_t weekday() const { return calc_weekday(daynr(), false); }
+    inline auto day_of_week() const { return (weekday() + 1) % 7 + 1; }
+
+    // The bits in week_format has the following meaning:
+    // WEEK_MONDAY_FIRST (0)
+    //  If not set:
+    //      Sunday is first day of week
+    //  If set:
+    //      Monday is first day of week
+    //
+    // WEEK_YEAR (1)
+    //  If not set:
+    //      Week is in range 0-53
+    //      Week 0 is returned for the the last week of the previous year (for
+    //      a date at start of january) In this case one can get 53 for the
+    //      first week of next year.  This flag ensures that the week is
+    //      relevant for the given year. Note that this flag is only
+    //      relevant if WEEK_JANUARY is not set.
+    //  If set:
+    //      Week is in range 1-53.
+    //      In this case one may get week 53 for a date in January (when
+    //      the week is that last week of previous year) and week 1 for a
+    //      date in December.
+    //
+    // WEEK_FIRST_WEEKDAY (2)
+    //  If not set
+    //      Weeks are numbered according to ISO 8601:1988
+    //  If set
+    //      The week that contains the first 'first-day-of-week' is week 1.
+    //
+    // ISO 8601:1988 means that
+    //      if the week containing January 1 has
+    //      four or more days in the new year, then it is week 1;
+    //      Otherwise it is the last week of the previous year, and the
+    //      next week is week 1.
+    uint8_t week(uint8_t) const;
+
+    uint32_t year_week(uint8_t mode) const;
+
+    // Add interval
+    bool date_add_interval(const TimeInterval& interval, TimeUnit unit);
+
+    //unix_timestamp is called with a timezone argument,
+    //it returns seconds of the value of date literal since '1970-01-01 00:00:00' UTC
+    bool unix_timestamp(int64_t* timestamp, const std::string& timezone) const;
+    bool unix_timestamp(int64_t* timestamp, const cctz::time_zone& ctz) const;
+
+    //construct datetime_value from timestamp and timezone
+    //timestamp is an internal timestamp value representing seconds since '1970-01-01 00:00:00' UTC
+    bool from_unixtime(int64_t, const std::string& timezone);
+    bool from_unixtime(int64_t, const cctz::time_zone& ctz);
+
+    bool operator==(const VecDateTimeValue& other) const {
+        // NOTE: This is not same with MySQL.
+        // MySQL convert both to int with left value type and then compare
+        // We think all fields equals.
+        int64_t v1 = to_int64_datetime_packed();
+        int64_t v2 = other.to_int64_datetime_packed();
+        return v1 == v2;
+    }
+
+    bool operator!=(const VecDateTimeValue& other) const { return !(*this == other); }
+
+    // Now, we don't support TIME_TIME type,
+    bool operator<=(const VecDateTimeValue& other) const { return !(*this > other); }
+
+    bool operator>=(const VecDateTimeValue& other) const { return !(*this < other); }
+
+    bool operator<(const VecDateTimeValue& other) const {
+        int64_t v1 = to_int64_datetime_packed();
+        int64_t v2 = other.to_int64_datetime_packed();
+        return v1 < v2;
+    }
+
+    bool operator>(const VecDateTimeValue& other) const {
+        int64_t v1 = to_int64_datetime_packed();
+        int64_t v2 = other.to_int64_datetime_packed();
+        return v1 > v2;
+    }
+
+    const char* month_name() const;
+
+    const char* day_name() const;
+
+    VecDateTimeValue& operator++() {
+        switch (_type) {
+        case TIME_DATE: {
+            TimeInterval interval(DAY, 1, false);
+            date_add_interval(interval, DAY);
+            break;
+        }
+        case TIME_DATETIME: {
+            TimeInterval interval(SECOND, 1, false);
+            date_add_interval(interval, SECOND);
+            break;
+        }
+        case TIME_TIME: {
+            TimeInterval interval(SECOND, 1, false);
+            date_add_interval(interval, SECOND);
+            break;
+        }
+        }
+        return *this;
+    }
+
+    void to_datetime_val(doris_udf::DateTimeVal* tv) const {
+        tv->packed_time = to_int64_datetime_packed();
+        tv->type = _type;
+    }
+
+    static VecDateTimeValue from_datetime_val(const doris_udf::DateTimeVal& tv) {
+        VecDateTimeValue value;
+        value.from_packed_time(tv.packed_time);
+        if (tv.type == TIME_DATE) {
+            value.cast_to_date();
+        }
+        return value;
+    }
+
+    inline uint32_t hash(int seed) const { return HashUtil::hash(this, sizeof(*this), seed); }
+
+    int day_of_year() const { return daynr() - calc_daynr(_year, 1, 1) + 1; }
+
+    // TODO(zhaochun): local time ???
+    static VecDateTimeValue local_time();
+
+    std::string debug_string() const {
+        char buf[64];
+        char* end = to_string(buf);
+        return std::string(buf, end - buf);
+    }
+
+    static VecDateTimeValue datetime_min_value() {
+        static VecDateTimeValue _s_min_datetime_value(0, TIME_DATETIME, 0, 0, 0, 0, 1, 1);
+        return _s_min_datetime_value;
+    }
+
+    static VecDateTimeValue datetime_max_value() {
+        static VecDateTimeValue _s_max_datetime_value(0, TIME_DATETIME, 23, 59, 59, 9999, 12, 31);
+        return _s_max_datetime_value;
+    }
+
+    int64_t second_diff(const VecDateTimeValue& rhs) const {
+        int day_diff = daynr() - rhs.daynr();
+        int time_diff = (hour() * 3600 + minute() * 60 + second()) -
+                        (rhs.hour() * 3600 + rhs.minute() * 60 + rhs.second());
+        return day_diff * 3600 * 24 + time_diff;
+    }
+
+    int64_t time_part_diff(const VecDateTimeValue& rhs) const {
+        int time_diff = (hour() * 3600 + minute() * 60 + second()) -
+                        (rhs.hour() * 3600 + rhs.minute() * 60 + rhs.second());
+        return time_diff;
+    }
+
+    void set_type(int type);
+
+    int type() const { return _type; }
+
+    bool is_valid_date() const { return !check_range(_year, _month, _day,
+            _hour, _minute, _second, _type) && _month > 0 && _day > 0; }
+
+private:
+    // Used to make sure sizeof VecDateTimeValue
+    friend class UnusedClass;
+
+    void from_packed_time(int64_t packed_time) {
+        int64_t ymdhms = packed_time >> 24;
+        int64_t ymd = ymdhms >> 17;
+        int64_t hms = ymdhms % (1 << 17);
+
+        _day = ymd % (1 << 5);
+        int64_t ym = ymd >> 5;
+        _month = ym % 13;
+        _year = ym / 13;
+        _year %= 10000;
+        _second = hms % (1 << 6);
+        _minute = (hms >> 6) % (1 << 6);
+        _hour = (hms >> 12);
+        _neg = 0;
+        _type = TIME_DATETIME;
+    }
+
+    int64_t make_packed_time(int64_t time, int64_t second_part) const {
+        return (time << 24) + second_part;
+    }
+
+    // To compatible with MySQL
+    int64_t to_int64_datetime_packed() const {
+        int64_t ymd = ((_year * 13 + _month) << 5) | _day;
+        int64_t hms = (_hour << 12) | (_minute << 6) | _second;
+        int64_t tmp = make_packed_time(((ymd << 17) | hms), 0);
+        return _neg ? -tmp : tmp;
+    }
+
+    int64_t to_int64_date_packed() const {
+        int64_t ymd = ((_year * 13 + _month) << 5) | _day;
+        int64_t tmp = make_packed_time(ymd << 17, 0);
+        return _neg ? -tmp : tmp;
+    }
+
+    // Used to construct from int value
+    int64_t standardize_timevalue(int64_t value);
+
+    // Used to convert to a string.
+    char* append_date_buffer(char* to) const;
+    char* append_time_buffer(char* to) const;
+    char* to_datetime_buffer(char* to) const;
+    char* to_date_buffer(char* to) const;
+    char* to_time_buffer(char* to) const;
+
+    // Used to convert to uint64_t
+    int64_t to_datetime_int64() const;
+    int64_t to_date_int64() const;
+    int64_t to_time_int64() const;
+
+    static uint8_t calc_week(const VecDateTimeValue& value, uint8_t mode, uint32_t* year);
+
+    // This is private function which modify date but modify `_type`
+    bool get_date_from_daynr(uint64_t);
+
+    // Helper to set max, min, zero
+    void set_zero(int type);
+    void set_max_time(bool neg);
+
+    bool from_date_format_str(const char* format, int format_len, const char* value, int value_len,
+                              const char** sub_val_end);
+
+    // 1 bits for neg. 3 bits for type. 12bit for second
+    uint16_t _neg : 1;  // Used for time value.
+    uint16_t _type : 3; // Which type of this value.
+    uint16_t _second : 12;
+    uint8_t _minute;
+    uint8_t _hour;
+    uint8_t _day;
+    uint8_t _month;
+    uint16_t _year;
+
+    VecDateTimeValue(uint8_t neg, uint8_t type, uint8_t hour, uint8_t minute, uint8_t second,
+                  uint16_t year, uint8_t month, uint8_t day)
+            : _neg(neg),
+              _type(type),
+              _second(second),
+              _minute(minute),
+              _hour(hour),
+              _day(day),
+              _month(month),
+              _year(year) {}
+
+    // RE2 obj is thread safe
+    static RE2 time_zone_offset_format_reg;
+};
+
+// only support DATE - DATE (no support DATETIME - DATETIME)
+std::size_t operator-(const VecDateTimeValue& v1, const VecDateTimeValue& v2);
+
+std::ostream& operator<<(std::ostream& os, const VecDateTimeValue& value);
+
+std::size_t hash_value(VecDateTimeValue const& value);
+
+} // namespace doris
+
+namespace std {
+template <>
+struct hash<doris::vectorized::VecDateTimeValue> {
+    size_t operator()(const doris::vectorized::VecDateTimeValue& v) const { return doris::vectorized::hash_value(v); }
+};
+} // namespace std
+
+#endif

--- a/be/src/vec/sink/mysql_result_writer.cpp
+++ b/be/src/vec/sink/mysql_result_writer.cpp
@@ -25,7 +25,7 @@
 #include "vec/common/assert_cast.h"
 #include "vec/exprs/vexpr.h"
 #include "vec/exprs/vexpr_context.h"
-
+#include "vec/runtime/vdatetime_value.h"
 namespace doris {
 namespace vectorized {
 VMysqlResultWriter::VMysqlResultWriter(BufferControlBlock* sinker,

--- a/be/test/vec/exprs/vexpr_test.cpp
+++ b/be/test/vec/exprs/vexpr_test.cpp
@@ -21,7 +21,7 @@
 #include "testutil/desc_tbl_builder.h"
 #include "vec/exprs/vliteral.h"
 #include "vec/utils/util.hpp"
-
+#include "vec/runtime/vdatetime_value.h"
 TEST(TEST_VEXPR, ABSTEST) {
     doris::ChunkAllocator::init_instance(4096);
     doris::ObjectPool object_pool;
@@ -310,17 +310,17 @@ TEST(TEST_VEXPR, LITERALTEST) {
         ASSERT_FLOAT_EQ(v, 1024.0);
     }
     {
-        DateTimeValue data_time_value;
+        vectorized::VecDateTimeValue data_time_value;
         const char* date = "20210407";
         data_time_value.from_date_str(date, strlen(date));
-        __int128_t dt;
-        memcpy(&dt, &data_time_value, sizeof(__int128_t));
+        __int64_t dt;
+        memcpy(&dt, &data_time_value, sizeof(__int64_t));
         VLiteral literal(create_literal<TYPE_DATETIME, std::string>(std::string(date)));
         Block block;
         int ret = -1;
         literal.execute(nullptr, &block, &ret);
         auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<__int128_t>();
+        auto v = (*ctn.column)[0].get<__int64_t>();
         ASSERT_EQ(v, dt);
     }
     {

--- a/be/test/vec/function/function_test_util.h
+++ b/be/test/vec/function/function_test_util.h
@@ -33,20 +33,20 @@
 #include "vec/functions/function_string.h"
 #include "vec/functions/function_string_to_string.h"
 #include "vec/functions/simple_function_factory.h"
-
+#include "vec/runtime/vdatetime_value.h"
 namespace doris {
 namespace vectorized {
 
 using DataSet = std::vector<std::pair<std::vector<std::any>, std::any>>;
-__int128 str_to_data_time(std::string datetime_str, bool data_time = true) {
-    DateTimeValue v;
+int64_t str_to_data_time(std::string datetime_str, bool data_time = true) {
+    VecDateTimeValue v;
     v.from_date_str(datetime_str.c_str(), datetime_str.size());
     if (data_time) { //bool data_time only to simplifly means data_time or data to cast, just use in time-functions uint test
         v.to_datetime();
     } else {
         v.cast_to_date();
     }
-    return binary_cast<doris::DateTimeValue, Int128>(v);
+    return binary_cast<doris::vectorized::VecDateTimeValue, Int64>(v);
 }
 
 template <typename ColumnType, typename Column, typename NullColumn>
@@ -171,7 +171,7 @@ void check_function(const std::string& func_name, const std::vector<std::any>& i
                                                     is_const, row_size);
         } else if (tp == TypeIndex::DateTime) {
             static std::string date_time_format("%Y-%m-%d %H:%i:%s");
-            auto col = ColumnInt128::create();
+            auto col = ColumnInt64::create();
 
             for (int j = 0; j < row_size; j++) {
                 if (data_set[j].first[i].type() == typeid(Null)) {
@@ -180,7 +180,7 @@ void check_function(const std::string& func_name, const std::vector<std::any>& i
                     continue;
                 }
                 auto datetime_str = std::any_cast<std::string>(data_set[j].first[i]);
-                DateTimeValue v;
+                VecDateTimeValue v;
                 v.from_date_format_str(date_time_format.c_str(), date_time_format.size(),
                                        datetime_str.c_str(), datetime_str.size());
                 v.to_datetime();
@@ -191,7 +191,7 @@ void check_function(const std::string& func_name, const std::vector<std::any>& i
                                                      is_const, row_size);
         } else if (tp == TypeIndex::Date) {
             static std::string date_time_format("%Y-%m-%d");
-            auto col = ColumnInt128::create();
+            auto col = ColumnInt64::create();
 
             for (int j = 0; j < row_size; j++) {
                 if (data_set[j].first[i].type() == typeid(Null)) {
@@ -200,7 +200,7 @@ void check_function(const std::string& func_name, const std::vector<std::any>& i
                     continue;
                 }
                 auto datetime_str = std::any_cast<std::string>(data_set[j].first[i]);
-                DateTimeValue v;
+                VecDateTimeValue v;
                 v.from_date_format_str(date_time_format.c_str(), date_time_format.size(),
                                        datetime_str.c_str(), datetime_str.size());
                 v.cast_to_date();

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -200,7 +200,7 @@ visible_functions = [
         '15FunctionContextERKNS1_11DateTimeValE', '', '', 'vec', 'ALWAYS_NULLABLE'],
     [['yearweek'], 'INT', ['DATETIME'],
         '_ZN5doris18TimestampFunctions9year_weekEPN9doris_udf15FunctionContextERKNS1_11DateTimeValE',
-        '', '', '', ''],
+        '', '', 'vec', 'ALWAYS_NULLABLE'],
     [['yearweek'], 'INT', ['DATETIME', 'INT'],
         '_ZN5doris18TimestampFunctions9year_weekEPN9doris_udf15FunctionContextERKNS1_11DateTimeValERKNS1_6IntValE',
         '', '', '', ''],


### PR DESCRIPTION
## Proposed changes
**Now this type is a temp solution with little changes, maybe large refactoring follow-up.**

remove **_microsecond** to reduce memory, and reorder the variables;
   before int128  16 bytes  --->  after int64 8 bytes 
this is a difference between Vectorization mode and Rowbatch mode with DateTimeValue;

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [ ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
