### PR TITLE
built-in data type should be initialized manually

### DIFF
--- a/be/src/exec/blocking_join_node.cpp
+++ b/be/src/exec/blocking_join_node.cpp
@@ -30,7 +30,8 @@ namespace doris {
 BlockingJoinNode::BlockingJoinNode(const std::string& node_name, const TJoinOp::type join_op,
                                    ObjectPool* pool, const TPlanNode& tnode,
                                    const DescriptorTbl& descs)
-        : ExecNode(pool, tnode, descs), _node_name(node_name), _join_op(join_op) {}
+        : ExecNode(pool, tnode, descs), _node_name(node_name), _join_op(join_op),
+          _left_side_eos(false) {}
 
 Status BlockingJoinNode::init(const TPlanNode& tnode, RuntimeState* state) {
     return ExecNode::init(tnode, state);
@@ -118,7 +119,6 @@ Status BlockingJoinNode::open(RuntimeState* state) {
 
     RETURN_IF_ERROR(open_status);
 
-    _left_side_eos = false;
     // Seed left child in preparation for get_next().
     while (true) {
         RETURN_IF_ERROR(child(0)->get_next(state, _left_batch.get(), &_left_side_eos));

--- a/be/src/exec/blocking_join_node.cpp
+++ b/be/src/exec/blocking_join_node.cpp
@@ -118,6 +118,7 @@ Status BlockingJoinNode::open(RuntimeState* state) {
 
     RETURN_IF_ERROR(open_status);
 
+    _left_side_eos = false;
     // Seed left child in preparation for get_next().
     while (true) {
         RETURN_IF_ERROR(child(0)->get_next(state, _left_batch.get(), &_left_side_eos));

--- a/be/src/vec/exec/vblocking_join_node.cpp
+++ b/be/src/vec/exec/vblocking_join_node.cpp
@@ -30,7 +30,8 @@ namespace doris::vectorized {
 VBlockingJoinNode::VBlockingJoinNode(const std::string& node_name, const TJoinOp::type join_op,
                                    ObjectPool* pool, const TPlanNode& tnode,
                                    const DescriptorTbl& descs)
-        : ExecNode(pool, tnode, descs), _node_name(node_name), _join_op(join_op) {}
+        : ExecNode(pool, tnode, descs), _node_name(node_name), _join_op(join_op),
+          _left_side_eos(false) {}
 
 Status VBlockingJoinNode::init(const TPlanNode& tnode, RuntimeState* state) {
     return ExecNode::init(tnode, state);
@@ -104,7 +105,6 @@ Status VBlockingJoinNode::open(RuntimeState* state) {
 
     RETURN_IF_ERROR(open_status);
 
-    _left_side_eos = false;
     // Seed left child in preparation for get_next().
     while (true) {
         _left_block.clear_column_data();

--- a/be/src/vec/exec/vblocking_join_node.cpp
+++ b/be/src/vec/exec/vblocking_join_node.cpp
@@ -104,6 +104,7 @@ Status VBlockingJoinNode::open(RuntimeState* state) {
 
     RETURN_IF_ERROR(open_status);
 
+    _left_side_eos = false;
     // Seed left child in preparation for get_next().
     while (true) {
         _left_block.clear_column_data();


### PR DESCRIPTION
## Proposed changes

built-in data type should be initialized manually,sush as int,bool. the operation of debug is different from that of release when initializing variables. Debug assigns each byte bit to 0xCC (Note 1), and the assignment of release is similar to random,if variables is not be initialized manually, this is a dangerous behavior, result in error.

case as follows:the result is wrong in debug mode
create table t2 on cluster test_cluster(tc1 decimal(15,2),tc2 decimal(15,2))engine=MergeTree()order by tc1;
insert into t2 values(11.11,22.22);
insert into t2 values(11.11,22.22);
insert into t2 values(11.11,22.22);
insert into t2 values(33.33,44.44);
insert into t2 values(33.33,55.44);
select * from t2 where tc2 > (select avg(tc2) from t2 t3); 

## Types of changes

What types of changes does your code introduce to Doris?
_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Code refactor (Modify the code structure, format the code, etc...)
- [ ] Optimization. Including functional usability improvements and performance improvements.
- [ ] Dependency. Such as changes related to third-party components.
- [ ] Other.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have created an issue on (Fix #ISSUE) and described the bug/feature there in detail
- [x ] Compiling and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If these changes need document changes, I have updated the document
- [ ] Any dependent changes have been merged

## Further comments

If this is a relatively large or complex change, kick off the discussion at dev@doris.apache.org by explaining why you chose the solution you did and what alternatives you considered, etc...
