### PR TITLE
[Opt] vectorized stream_sender hash val compute

### DIFF
--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -154,7 +154,7 @@ public:
                         LOG(INFO) << "will use local Exchange, dest_node_id is : "<<_dest_node_id;
                     }
                 }
-
+    
     virtual ~Channel() {
         if (_closure != nullptr && _closure->unref()) {
             delete _closure;


### PR DESCRIPTION
## 分区计算向量化优化

优化shuffle join、bucket shuffle join等需要按桶分发数据的所有场景
有10%~20%的提速效果

<img width="1019" alt="分区计算2" src="https://user-images.githubusercontent.com/35688959/146767331-34985e2b-34ad-4691-93c2-d7f5cd33300b.png">

**黄色块表示一次处理的基本单位**

- 优化前：一行一行计算哈希值
- 优化后：一列哈希值用数组临时存储，一列列批量计算哈希值

排序版本由于代码实现有些问题，效果不好
最终决定不采用排序版本，就简单的改成按列计算

