### PR TITLE
rollback dict array in column_reader

### DIFF
--- a/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
@@ -233,10 +233,8 @@ bool BinaryDictPageDecoder::is_dict_encoding() const {
     return _encoding_type == DICT_ENCODING;
 }
 
-void BinaryDictPageDecoder::set_dict_decoder(PageDecoder* dict_decoder, uint32_t* dict_start_offset_array, uint32_t* dict_len_array) {
+void BinaryDictPageDecoder::set_dict_decoder(PageDecoder* dict_decoder) {
     _dict_decoder = (BinaryPlainPageDecoder*)dict_decoder;
-    _start_offset_array = dict_start_offset_array;
-    _len_array = dict_len_array;
     _bit_shuffle_ptr = reinterpret_cast<BitShufflePageDecoder<OLAP_FIELD_TYPE_INT>*>(_data_page_decoder.get());
 };
 

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.h
@@ -115,7 +115,7 @@ public:
 
     bool is_dict_encoding() const;
 
-    void set_dict_decoder(PageDecoder* dict_decoder, uint32_t* dict_start_offset_array, uint32_t* dict_len_array);
+    void set_dict_decoder(PageDecoder* dict_decoder);
 
     ~BinaryDictPageDecoder();
 

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -459,9 +459,6 @@ FileColumnIterator::FileColumnIterator(ColumnReader* reader) : _reader(reader) {
 
 FileColumnIterator::~FileColumnIterator() {
     _opts.mem_tracker->Release(_opts.mem_tracker->consumption());
-
-    delete[] _dict_start_offset_array;
-    delete[] _dict_len_array;
 }
 
 Status FileColumnIterator::seek_to_first() {
@@ -677,21 +674,8 @@ Status FileColumnIterator::_read_data_page(const OrdinalPageIndexIterator& iter)
                 // PLAIN_ENCODING is supported for dict page right now
                 _dict_decoder.reset(new BinaryPlainPageDecoder(dict_data));
                 RETURN_IF_ERROR(_dict_decoder->init());
-
-                BinaryPlainPageDecoder* pd_decoder = (BinaryPlainPageDecoder*)_dict_decoder.get();
-                _dict_start_offset_array = new uint32_t[pd_decoder->_num_elems];
-                _dict_len_array = new uint32_t[pd_decoder->_num_elems];
-                
-                // todo(wb) padding dict value for SIMD comparison
-                for (int i = 0; i < pd_decoder->_num_elems; i++) {
-                    const uint32_t start_offset = pd_decoder->offset(i);
-                    uint32_t len = pd_decoder->offset(i + 1) - start_offset;
-                    _dict_start_offset_array[i] = start_offset;
-                    _dict_len_array[i] = len;
-                }
-
             }
-            dict_page_decoder->set_dict_decoder(_dict_decoder.get(), _dict_start_offset_array, _dict_len_array);
+            dict_page_decoder->set_dict_decoder(_dict_decoder.get());
         }
     }
     return Status::OK();

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -309,9 +309,6 @@ private:
 
     // keep dict page decoder
     std::unique_ptr<PageDecoder> _dict_decoder;
-    // todo(wb) add dict info to mem tracker
-    uint32_t* _dict_start_offset_array = nullptr;
-    uint32_t* _dict_len_array = nullptr;
 
     // keep dict page handle to avoid released
     PageHandle _dict_page_handle;

--- a/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
@@ -77,17 +77,7 @@ public:
         PageDecoderOptions decoder_options;
         BinaryDictPageDecoder page_decoder(s.slice(), decoder_options);
 
-        BinaryPlainPageDecoder* pd_decoder = (BinaryPlainPageDecoder*)dict_page_decoder.get();
-        std::unique_ptr<uint32_t[]> dict_start_offset_array(new uint32_t[pd_decoder->_num_elems]);
-        std::unique_ptr<uint32_t[]> dict_len_array(new uint32_t[pd_decoder->_num_elems]);
-        for (int i = 0; i < pd_decoder->_num_elems; i++) {
-            const uint32_t start_offset = pd_decoder->offset(i);
-            uint32_t len = pd_decoder->offset(i + 1) - start_offset;
-            dict_start_offset_array[i] = start_offset;
-            dict_len_array[i] = len;
-        }
-
-        page_decoder.set_dict_decoder(dict_page_decoder.get(), dict_start_offset_array.get(), dict_len_array.get());
+        page_decoder.set_dict_decoder(dict_page_decoder.get());
 
         status = page_decoder.init();
         ASSERT_TRUE(status.ok());
@@ -183,17 +173,7 @@ public:
             BinaryDictPageDecoder page_decoder(results[slice_index].slice(), decoder_options);
             status = page_decoder.init();
 
-            BinaryPlainPageDecoder* pd_decoder = (BinaryPlainPageDecoder*)dict_page_decoder.get();
-            std::unique_ptr<uint32_t[]> dict_start_offset_array(new uint32_t[pd_decoder->_num_elems]);
-            std::unique_ptr<uint32_t[]> dict_len_array(new uint32_t[pd_decoder->_num_elems]);
-            for (int i = 0; i < pd_decoder->_num_elems; i++) {
-                const uint32_t start_offset = pd_decoder->offset(i);
-                uint32_t len = pd_decoder->offset(i + 1) - start_offset;
-                dict_start_offset_array[i] = start_offset;
-                dict_len_array[i] = len;
-            }
-
-            page_decoder.set_dict_decoder(dict_page_decoder.get(), dict_start_offset_array.get(), dict_len_array.get());
+            page_decoder.set_dict_decoder(dict_page_decoder.get());
             ASSERT_TRUE(status.ok());
 
             //check values

--- a/be/test/tools/benchmark_tool.cpp
+++ b/be/test/tools/benchmark_tool.cpp
@@ -178,17 +178,7 @@ public:
             BinaryDictPageDecoder page_decoder(src.slice(), decoder_options);
             page_decoder.init();
 
-            BinaryPlainPageDecoder* pd_decoder = (BinaryPlainPageDecoder*)dict_page_decoder.get();
-            std::unique_ptr<uint32_t[]> dict_start_offset_array(new uint32_t[pd_decoder->_num_elems]);
-            std::unique_ptr<uint32_t[]> dict_len_array(new uint32_t[pd_decoder->_num_elems]);
-            for (int i = 0; i < pd_decoder->_num_elems; i++) {
-                const uint32_t start_offset = pd_decoder->offset(i);
-                uint32_t len = pd_decoder->offset(i + 1) - start_offset;
-                dict_start_offset_array[i] = start_offset;
-                dict_len_array[i] = len;
-            }
-
-            page_decoder.set_dict_decoder(dict_page_decoder.get(), dict_start_offset_array.get(), dict_len_array.get());
+            page_decoder.set_dict_decoder(dict_page_decoder.get());
 
             //check values
             size_t num = page_start_ids[slice_index + 1] - page_start_ids[slice_index];


### PR DESCRIPTION
字典读取方式的优化暂时还没用上，需要等后续的pr提交
目前会对原有逻辑造成影响，带来不必要的内存开销
因此临时回滚这个优化