### PR TITLE
[deps](openssl) upgrade openssl to 1.1.1m (#7446)

### DIFF
--- a/be/src/util/aes_util.cpp
+++ b/be/src/util/aes_util.cpp
@@ -102,7 +102,6 @@ static int do_encrypt(EVP_CIPHER_CTX* aes_ctx, const EVP_CIPHER* cipher,
 int AesUtil::encrypt(AesMode mode, const unsigned char* source, uint32_t source_length,
                      const unsigned char* key, uint32_t key_length, const unsigned char* iv,
                      bool padding, unsigned char* encrypt) {
-    EVP_CIPHER_CTX aes_ctx;
     const EVP_CIPHER* cipher = get_evp_type(mode);
     /* The encrypt key to be used for encryption */
     unsigned char encrypt_key[AES_MAX_KEY_LENGTH / 8];
@@ -111,11 +110,12 @@ int AesUtil::encrypt(AesMode mode, const unsigned char* source, uint32_t source_
     if (cipher == nullptr || (EVP_CIPHER_iv_length(cipher) > 0 && !iv)) {
         return AES_BAD_DATA;
     }
-    EVP_CIPHER_CTX_init(&aes_ctx);
+    EVP_CIPHER_CTX* aes_ctx = EVP_CIPHER_CTX_new();
+    EVP_CIPHER_CTX_reset(aes_ctx);
     int length = 0;
-    int ret = do_encrypt(&aes_ctx, cipher, source, source_length, encrypt_key, iv, padding, encrypt,
+    int ret = do_encrypt(aes_ctx, cipher, source, source_length, encrypt_key, iv, padding, encrypt,
                          &length);
-    EVP_CIPHER_CTX_cleanup(&aes_ctx);
+    EVP_CIPHER_CTX_free(aes_ctx);
     if (ret == 0) {
         ERR_clear_error();
         return AES_BAD_DATA;
@@ -150,7 +150,6 @@ static int do_decrypt(EVP_CIPHER_CTX* aes_ctx, const EVP_CIPHER* cipher,
 int AesUtil::decrypt(AesMode mode, const unsigned char* encrypt, uint32_t encrypt_length,
                      const unsigned char* key, uint32_t key_length, const unsigned char* iv,
                      bool padding, unsigned char* decrypt_content) {
-    EVP_CIPHER_CTX aes_ctx;
     const EVP_CIPHER* cipher = get_evp_type(mode);
 
     /* The encrypt key to be used for decryption */
@@ -160,12 +159,12 @@ int AesUtil::decrypt(AesMode mode, const unsigned char* encrypt, uint32_t encryp
     if (cipher == nullptr || (EVP_CIPHER_iv_length(cipher) > 0 && !iv)) {
         return AES_BAD_DATA;
     }
-
-    EVP_CIPHER_CTX_init(&aes_ctx);
+    EVP_CIPHER_CTX* aes_ctx = EVP_CIPHER_CTX_new();
+    EVP_CIPHER_CTX_reset(aes_ctx);
     int length = 0;
-    int ret = do_decrypt(&aes_ctx, cipher, encrypt, encrypt_length, encrypt_key, iv, padding,
+    int ret = do_decrypt(aes_ctx, cipher, encrypt, encrypt_length, encrypt_key, iv, padding,
                          decrypt_content, &length);
-    EVP_CIPHER_CTX_cleanup(&aes_ctx);
+    EVP_CIPHER_CTX_free(aes_ctx);
     if (ret > 0) {
         return length;
     } else {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,13 +20,13 @@ FROM centos:7 AS builder
 # install dependencies
 RUN yum makecache && yum -y update && yum -y groupinstall 'Development Tools' && \
     yum install -y byacc automake java-11-openjdk-devel java-1.8.0-openjdk-devel libtool bison binutils-devel zip \
-    unzip ncurses-devel curl git wget python2 glibc-static java-1.8.0-openjdk-devel \
+    unzip ncurses-devel curl git wget python2 glibc-static java-1.8.0-openjdk-devel ccache \
     libstdc++-static which psl libpsl-devel centos-release-scl && \
     yum install -y devtoolset-10 devtoolset-10-gcc devtoolset-10-libubsan-devel devtoolset-10-liblsan-devel \
     devtoolset-10-libasan-devel
 
 # build cmake
-ARG CMAKE_VERSION=3.19.8
+ARG CMAKE_VERSION=3.22.1
 ARG CMAKE_BASE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}
 RUN wget ${CMAKE_BASE_URL}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh -q -O /tmp/cmake-install.sh && \
     chmod u+x /tmp/cmake-install.sh && \

--- a/thirdparty/CHANGELOG.md
+++ b/thirdparty/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 This file contains version of the third-party dependency libraries in the build-env image. The docker build-env image is apache/incubator-doris, and the tag is `build-env-${version}`
 
+## v20211220
+
+- Modified: OpenSSL 1.0.2k -> 1.1.1m
+- Modified: cmake 3.19.8 -> 3.22.1
+- Added: ccache
+
+## v20211215
+
+### Changes
+
+- Added: cyrus-sasl
+- Modified: librdkafka
+
 ## build-env-1.4.2
 
 ### Changes

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -58,10 +58,10 @@ LIBEVENT_SOURCE=libevent-release-2.1.12-stable
 LIBEVENT_MD5SUM="0d5a27436bf7ff8253420c8cf09f47ca"
 
 # openssl
-OPENSSL_DOWNLOAD="https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz"
-OPENSSL_NAME=openssl-1.0.2k.tar.gz
-OPENSSL_SOURCE=openssl-1.0.2k
-OPENSSL_MD5SUM="f965fc0bf01bf882b31314b61391ae65"
+OPENSSL_DOWNLOAD="https://github.com/openssl/openssl/archive/OpenSSL_1_1_1m.tar.gz"
+OPENSSL_NAME=openssl-OpenSSL_1_1_1m.tar.gz
+OPENSSL_SOURCE=openssl-OpenSSL_1_1_1m
+OPENSSL_MD5SUM="710c2368d28f1a25ab92e25b5b9b11ec"
 
 # thrift
 THRIFT_DOWNLOAD="http://archive.apache.org/dist/thrift/0.13.0/thrift-0.13.0.tar.gz"


### PR DESCRIPTION
这个pr是从apache doris主分支直接cherry-pick过来的，预期可以解决clang编译失败的问题
这个pr目前依赖apache doris的最新镜像（apache/incubator-doris:build-env-latest）
目前的主要问题是，doris-vec的代码基于apache doris的最新镜像使用gcc进行编译时候在link阶段会失败
因此在合入这个pr之前，首先要解决的是link失败的问题