### PR TITLE
[Bug] fix null equal null at case when && fix null first/last at desc

### DIFF
--- a/be/src/vec/exec/vsort_node.cpp
+++ b/be/src/vec/exec/vsort_node.cpp
@@ -191,7 +191,8 @@ Status VSortNode::pretreat_block(doris::vectorized::Block& block) {
         RETURN_IF_ERROR(ordering_expr->execute(&block, &_sort_description[i].column_number));
 
         _sort_description[i].direction = _is_asc_order[i] ? 1 : -1;
-        _sort_description[i].nulls_direction = _nulls_first[i] ? -1 : 1;
+        _sort_description[i].nulls_direction =
+                _nulls_first[i] ? -_sort_description[i].direction : _sort_description[i].direction;
     }
 
     sort_block(block, _sort_description, _offset + _limit);

--- a/be/src/vec/functions/function_case.h
+++ b/be/src/vec/functions/function_case.h
@@ -151,7 +151,7 @@ public:
             if constexpr (has_case) {
                 // TODO: need simd
                 for (int row_idx = 0; row_idx < rows_count; row_idx++) {
-                    if (!then_idx_ptr[row_idx] &&
+                    if (!then_idx_ptr[row_idx] && !case_column_ptr->is_null_at(row_idx) &&
                         case_column_ptr->compare_at(row_idx, row_idx, *when_column_ptr, -1) == 0) {
                         then_idx_ptr[row_idx] = i;
                     }
@@ -172,7 +172,8 @@ public:
 
                     // simd automatically
                     for (int row_idx = 0; row_idx < rows_count; row_idx++) {
-                        then_idx_ptr[row_idx] |= (!then_idx_ptr[row_idx]) * cond_raw_data[row_idx] * i;
+                        then_idx_ptr[row_idx] |=
+                                (!then_idx_ptr[row_idx]) * cond_raw_data[row_idx] * i;
                     }
                 }
             }


### PR DESCRIPTION
```sql
select case k1 when (select null) then "empty" else "p_test" end a from (select k1 from bigtable union select null) c order by a;

select a.k1 ak1, b.k1 bk1 from test a        right join baseall b on a.k1=b.k1 and b.k1>10        order by ak1 desc nulls first, bk1;
```
